### PR TITLE
feat: add bkit-starter plugin to marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,6 +10,28 @@
   },
   "plugins": [
     {
+      "name": "bkit-starter",
+      "description": "Korean learning guide for Claude Code beginners. No programming experience required. Includes 4 learning commands.",
+      "version": "1.0.0",
+      "author": {
+        "name": "POPUP STUDIO PTE. LTD.",
+        "email": "contact@popupstudio.ai"
+      },
+      "repository": "https://github.com/popup-studio-ai/bkit-starter",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/popup-studio-ai/bkit-starter.git"
+      },
+      "category": "learning",
+      "keywords": [
+        "beginner",
+        "korean",
+        "tutorial",
+        "starter",
+        "learning"
+      ]
+    },
+    {
       "name": "bkit",
       "description": "Vibecoding Kit - PDCA methodology + Claude Code mastery for AI-native development. Includes 18 commands, 11 agents, 24 skills, and 6 hooks for structured development workflows.",
       "version": "1.1.0",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ bkit is a Claude Code plugin that transforms how you build software with AI. It 
 
 ---
 
+### 🚀 초보자라면?
+
+> **Claude Code가 처음이신가요?**
+>
+> [bkit-starter](https://github.com/popup-studio-ai/bkit-starter)로 시작하세요!
+>
+> - 완전한 한글 가이드
+> - 프로그래밍 경험 없이도 시작 가능
+> - 첫 프로젝트 만들기 체험
+>
+> ```bash
+> /plugin install bkit-starter
+> ```
+>
+> bkit은 bkit-starter를 마스터한 후 사용하는 고급 확장 버전입니다.
+
+---
+
 ## Quick Start
 
 ### Option 1: Marketplace Installation (Recommended)


### PR DESCRIPTION
## Summary
- Add bkit-starter as a new plugin entry in marketplace.json
- Korean learning guide for Claude Code beginners
- No programming experience required, includes 4 learning commands

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Check plugin entry has all required fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)