### PR TITLE
fix: bkit-starter 명령어를 plugin enable으로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ bkit is a Claude Code plugin that transforms how you build software with AI. It 
 > - 첫 프로젝트 만들기 체험
 >
 > ```bash
-> /plugin install bkit-starter
+> /plugin enable bkit-starter
 > ```
 >
 > bkit은 bkit-starter를 마스터한 후 사용하는 고급 확장 버전입니다.


### PR DESCRIPTION
## Summary
- bkit-starter 설치 명령어를 `plugin install`에서 `plugin enable`로 수정

## Test plan
- [ ] README.md에서 명령어 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)