### PR TITLE
feat: add Plan Plus skill — brainstorming-enhanced PDCA planning

### DIFF
--- a/skills/pdca/SKILL.md
+++ b/skills/pdca/SKILL.md
@@ -83,6 +83,10 @@ task-template: "[PDCA] {feature}"
 
 **Output Path**: `docs/01-plan/features/{feature}.plan.md`
 
+> **Tip**: For features with ambiguous requirements or multiple implementation approaches,
+> use `/plan-plus {feature}` instead. Plan Plus adds brainstorming phases (intent discovery,
+> alternatives exploration, YAGNI review) before document generation for higher-quality plans.
+
 ### design (Design Phase)
 
 1. Verify Plan document exists (required - suggest running plan first if missing)

--- a/skills/plan-plus/SKILL.md
+++ b/skills/plan-plus/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: plan-plus
+description: |
+  Plan Plus — Brainstorming-Enhanced PDCA Planning.
+  Combines intent discovery from brainstorming methodology with bkit PDCA's structured planning.
+  Produces higher-quality Plan documents by exploring user intent, comparing alternatives,
+  and applying YAGNI review before document generation.
+
+  Use proactively when user mentions planning with brainstorming, intent discovery,
+  exploring alternatives, or wants a more thorough planning process.
+
+  Triggers: plan-plus, plan plus, brainstorming plan, enhanced plan, deep plan,
+  플랜 플러스, 브레인스토밍, 기획, 의도 탐색, 대안 탐색,
+  プランプラス, ブレインストーミング, 企画, 意図探索,
+  计划加强, 头脑风暴, 深度规划, 意图探索,
+  plan mejorado, lluvia de ideas, planificación profunda,
+  plan amélioré, remue-méninges, planification approfondie,
+  erweiterter Plan, Brainstorming, vertiefte Planung,
+  piano migliorato, brainstorming, pianificazione approfondita
+
+  Do NOT use for: simple tasks that don't need planning, code-only changes.
+argument-hint: "[feature]"
+user-invocable: true
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Task
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - AskUserQuestion
+imports:
+  - ${PLUGIN_ROOT}/templates/plan-plus.template.md
+next-skill: pdca design
+pdca-phase: plan
+task-template: "[Plan Plus] {feature}"
+---
+
+# Plan Plus — Brainstorming-Enhanced PDCA Planning
+
+> Combines brainstorming's intent discovery with bkit PDCA's structured planning to produce
+> higher-quality Plan documents through collaborative dialogue.
+
+## Overview
+
+Plan Plus enhances the standard `/pdca plan` by adding 4 brainstorming phases before document
+generation. This ensures that user intent is fully understood, alternatives are explored,
+and unnecessary features are removed before any implementation begins.
+
+**When to use Plan Plus instead of `/pdca plan`:**
+- The feature has ambiguous or complex requirements
+- Multiple implementation approaches are possible
+- You want to ensure YAGNI compliance from the start
+- The feature involves significant architectural decisions
+
+## HARD-GATE
+
+<HARD-GATE>
+Do NOT write any code, scaffold any project, or invoke any implementation skill
+until this entire process is complete and the user has approved the Plan document.
+This applies to EVERY feature regardless of perceived simplicity.
+A "simple" feature still goes through this process — the design can be short,
+but you MUST present it and get approval.
+</HARD-GATE>
+
+## Process Flow
+
+```
+Phase 0: Context Exploration (automatic)
+    ↓
+Phase 1: Intent Discovery (1 question at a time)
+    ↓
+Phase 2: Alternatives Exploration (2-3 approaches)
+    ↓
+Phase 3: YAGNI Review (multiSelect verification)
+    ↓
+Phase 4: Incremental Design Validation (section-by-section)
+    ↓
+Phase 5: Plan Document Generation (plan-plus.template.md)
+    ↓
+Phase 6: Next Steps → /pdca design {feature}
+```
+
+## Phase Details
+
+### Phase 0: Project Context Exploration (Automatic)
+
+Before asking any questions, explore the current project state:
+
+1. Read CLAUDE.md, package.json, pom.xml, etc. for project information
+2. Check recent 5 git commits (understand current work direction)
+3. Check existing `docs/01-plan/` documents (prevent duplication)
+4. Check `.bkit-memory.json` (check ongoing PDCA status)
+
+> Share exploration results briefly: "I've reviewed the current project state: ..."
+
+### Phase 1: Intent Discovery (Brainstorming Style)
+
+**Principle: One question at a time, prefer multiple choice**
+
+Use `AskUserQuestion` tool to discover the following in order:
+
+#### Q1. Core Purpose
+"What is the core problem this feature solves?"
+- Provide 3-4 choices (inferred from project context)
+- Always include a custom input option
+
+#### Q2. Target Users
+"Who will primarily use this feature?"
+- Admin / End user / Developer / External system
+
+#### Q3. Success Criteria
+"What criteria would indicate this feature is successful?"
+- Derive specific, measurable criteria
+
+#### Q4. Constraints (only when needed)
+Conflicts with existing systems, performance requirements, technical constraints, etc.
+
+> **Important**: Minimize questions. Clear features need only Q1-Q2.
+> Only proceed to Q3-Q4 for ambiguous features.
+
+### Phase 2: Alternatives Exploration (Brainstorming Core)
+
+**Always propose 2-3 approaches** with trade-offs for each.
+
+Format:
+```
+### Approach A: {name} — Recommended
+- Pros: ...
+- Cons: ...
+- Best for: ...
+
+### Approach B: {name}
+- Pros: ...
+- Cons: ...
+- Best for: ...
+
+### Approach C: {name} (optional)
+- Pros: ...
+- Cons: ...
+```
+
+> Present the recommended approach first with clear reasoning.
+> Use AskUserQuestion to let the user choose.
+
+### Phase 3: YAGNI Review (Brainstorming Core)
+
+Perform a YAGNI (You Ain't Gonna Need It) review on the selected approach:
+
+Use AskUserQuestion with `multiSelect: true`:
+"Select only what is essential for the first version:"
+
+List all features and move unselected items to Out of Scope.
+
+**Principle**: Don't abstract what can be done in 3 lines.
+Don't design for hypothetical future requirements.
+
+### Phase 4: Incremental Design Validation (Brainstorming Style)
+
+Present the design section by section, getting approval after each:
+
+1. Architecture overview → "Does this direction look right?"
+2. Key components/modules → "Does this structure look right?"
+3. Data flow → "Does this flow look right?"
+
+> If the user says "no" to any section, revise only that section and re-present.
+
+### Phase 5: Plan Document Generation
+
+Generate the Plan document using `plan-plus.template.md` with results from Phases 0-4.
+
+**Additional sections** (not in standard plan.template.md):
+- **User Intent Discovery** — Core problem, target users, success criteria from Phase 1
+- **Alternatives Explored** — Approaches compared in Phase 2
+- **YAGNI Review** — Included/deferred/removed items from Phase 3
+- **Brainstorming Log** — Key decisions from Phases 1-4
+
+**Output Path**: `docs/01-plan/features/{feature}.plan.md`
+
+After document generation, update PDCA status:
+- Create Task: `[Plan] {feature}`
+- Update .bkit-memory.json: phase = "plan"
+
+### Phase 6: Next Steps
+
+After Plan document generation:
+```
+Plan Plus completed
+Document: docs/01-plan/features/{feature}.plan.md
+Next step: /pdca design {feature}
+```
+
+## Key Principles
+
+| Principle | Origin | Application |
+|-----------|--------|-------------|
+| One question at a time | Brainstorming | Sequential questions via AskUserQuestion |
+| Explore alternatives | Brainstorming | Mandatory 2-3 approaches in Phase 2 |
+| YAGNI ruthlessly | Brainstorming | multiSelect verification in Phase 3 |
+| Incremental validation | Brainstorming | Section-by-section approval in Phase 4 |
+| HARD-GATE | Brainstorming | No code before approval (entire process) |
+| Context first | Brainstorming | Automatic exploration in Phase 0 |
+
+## Integration with PDCA
+
+Plan Plus produces the same output as `/pdca plan` and feeds seamlessly into the
+standard PDCA cycle:
+
+```
+/plan-plus {feature}     ← Enhanced planning with brainstorming
+    ↓
+/pdca design {feature}   ← Standard PDCA continues
+    ↓
+/pdca do {feature}
+    ↓
+/pdca analyze {feature}
+    ↓
+/pdca report {feature}
+```
+
+## Usage Examples
+
+```bash
+# Start brainstorming-enhanced planning
+/plan-plus user-authentication
+
+# After Plan Plus completes, continue with standard PDCA
+/pdca design user-authentication
+/pdca do user-authentication
+```

--- a/templates/plan-plus.template.md
+++ b/templates/plan-plus.template.md
@@ -1,0 +1,225 @@
+---
+template: plan-plus
+version: 1.0
+description: Brainstorming-enhanced PDCA Plan template with User Intent, Alternatives, and YAGNI sections
+variables:
+  - feature: Feature name
+  - date: Creation date (YYYY-MM-DD)
+  - author: Author
+  - project: Project name (from package.json or CLAUDE.md)
+  - version: Project version (from package.json)
+---
+
+# {feature} Planning Document
+
+> **Summary**: {One-line description}
+>
+> **Project**: {project}
+> **Version**: {version}
+> **Author**: {author}
+> **Date**: {date}
+> **Status**: Draft
+> **Method**: Plan Plus (Brainstorming-Enhanced PDCA)
+
+---
+
+## 1. User Intent Discovery
+
+### 1.1 Core Problem
+
+{The core problem this feature solves — discovered through brainstorming Q1}
+
+### 1.2 Target Users
+
+| User Type | Usage Context | Key Need |
+|-----------|---------------|----------|
+| {User type} | {Context} | {Key need} |
+
+### 1.3 Success Criteria
+
+- [ ] {Measurable success criterion 1}
+- [ ] {Measurable success criterion 2}
+
+### 1.4 Constraints
+
+| Constraint | Details | Impact |
+|------------|---------|--------|
+| {Constraint} | {Details} | High/Medium/Low |
+
+---
+
+## 2. Alternatives Explored
+
+### 2.1 Approach A: {name} {Mark "— Selected" if chosen}
+
+| Aspect | Details |
+|--------|---------|
+| **Summary** | {One-line description} |
+| **Pros** | {Advantages} |
+| **Cons** | {Disadvantages} |
+| **Effort** | {Estimated complexity: Low/Medium/High} |
+| **Best For** | {When this approach is most suitable} |
+
+### 2.2 Approach B: {name}
+
+| Aspect | Details |
+|--------|---------|
+| **Summary** | {One-line description} |
+| **Pros** | {Advantages} |
+| **Cons** | {Disadvantages} |
+| **Effort** | {Estimated complexity} |
+| **Best For** | {When this approach is most suitable} |
+
+### 2.3 Decision Rationale
+
+**Selected**: Approach {A/B}
+**Reason**: {Selection reason — based on specific trade-offs}
+
+---
+
+## 3. YAGNI Review
+
+### 3.1 Included (v1 Must-Have)
+
+- [ ] {Essential feature 1}
+- [ ] {Essential feature 2}
+- [ ] {Essential feature 3}
+
+### 3.2 Deferred (v2+ Maybe)
+
+| Feature | Reason for Deferral | Revisit When |
+|---------|---------------------|--------------|
+| {Feature} | {Why not needed now} | {When to reconsider} |
+
+### 3.3 Removed (Won't Do)
+
+| Feature | Reason for Removal |
+|---------|-------------------|
+| {Feature} | {Removal reason} |
+
+---
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- [ ] {Included item 1}
+- [ ] {Included item 2}
+- [ ] {Included item 3}
+
+### 4.2 Out of Scope
+
+- {Excluded item 1} — (from YAGNI Review)
+- {Excluded item 2}
+
+---
+
+## 5. Requirements
+
+### 5.1 Functional Requirements
+
+| ID | Requirement | Priority | Status |
+|----|-------------|----------|--------|
+| FR-01 | {Requirement description} | High/Medium/Low | Pending |
+| FR-02 | {Requirement description} | High/Medium/Low | Pending |
+
+### 5.2 Non-Functional Requirements
+
+| Category | Criteria | Measurement Method |
+|----------|----------|-------------------|
+| Performance | {e.g., Response time < 200ms} | {Tool/Method} |
+| Security | {e.g., OWASP Top 10 compliance} | {Verification method} |
+
+---
+
+## 6. Success Criteria
+
+### 6.1 Definition of Done
+
+- [ ] All functional requirements implemented
+- [ ] Unit tests written and passing
+- [ ] Code review completed
+- [ ] Documentation completed
+
+### 6.2 Quality Criteria
+
+- [ ] Test coverage above 80%
+- [ ] Zero lint errors
+- [ ] Build succeeds
+
+---
+
+## 7. Risks and Mitigation
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| {Risk 1} | High/Medium/Low | High/Medium/Low | {Mitigation plan} |
+| {Risk 2} | High/Medium/Low | High/Medium/Low | {Mitigation plan} |
+
+---
+
+## 8. Architecture Considerations
+
+### 8.1 Project Level Selection
+
+| Level | Characteristics | Recommended For | Selected |
+|-------|-----------------|-----------------|:--------:|
+| **Starter** | Simple structure (`components/`, `lib/`, `types/`) | Static sites, portfolios, landing pages | |
+| **Dynamic** | Feature-based modules, BaaS integration (bkend.ai) | Web apps with backend, SaaS MVPs, fullstack apps | |
+| **Enterprise** | Strict layer separation, DI, microservices | High-traffic systems, complex architectures | |
+
+### 8.2 Key Decisions
+
+| Decision | Options | Selected | Rationale |
+|----------|---------|----------|-----------|
+| {Decision} | {Option list} | {Selected} | {Rationale} |
+
+### 8.3 Component Overview
+
+```
+{Component structure diagram}
+```
+
+### 8.4 Data Flow
+
+```
+{Data flow diagram}
+```
+
+---
+
+## 9. Convention Prerequisites
+
+### 9.1 Applicable Conventions
+
+- [ ] Existing project conventions verified
+- [ ] Naming rules confirmed
+- [ ] Folder structure rules confirmed
+
+---
+
+## 10. Next Steps
+
+1. [ ] Write design document (`/pdca design {feature}`)
+2. [ ] Team review and approval
+3. [ ] Start implementation (`/pdca do {feature}`)
+
+---
+
+## Appendix: Brainstorming Log
+
+> Key decisions from Plan Plus Phases 1-4.
+
+| Phase | Question | Answer | Decision |
+|-------|----------|--------|----------|
+| Intent | {Question summary} | {Answer summary} | {Decision} |
+| Alternatives | {Compared items} | {Selection} | {Rationale} |
+| YAGNI | {Reviewed items} | {Include/Exclude} | {Reason} |
+
+---
+
+## Version History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 0.1 | {date} | Initial draft (Plan Plus) | {author} |


### PR DESCRIPTION
## Summary

- Add `/plan-plus` skill that enhances `/pdca plan` with brainstorming methodology
- Add `plan-plus.template.md` with User Intent, Alternatives, and YAGNI sections
- Add plan-plus reference tip to existing pdca skill's plan action

## Motivation

The standard `/pdca plan` creates plan documents directly from requirements. In practice, I found that adding a **brainstorming layer** before document generation significantly improves plan quality by:

1. **Discovering intent** — Understanding _why_ before _what_ through structured questions
2. **Exploring alternatives** — Comparing 2-3 approaches prevents premature commitment
3. **Applying YAGNI** — Removing unnecessary features before they enter the plan
4. **Incremental validation** — Getting user approval section-by-section reduces rework

This was tested on a real enterprise project (HunikFlow — Java/Angular low-code platform) where Plan Plus consistently produced more focused, actionable plans than direct planning.

## Changes

| File | Change | Description |
|------|--------|-------------|
| `skills/plan-plus/SKILL.md` | **New** | Plan Plus skill with 6-phase brainstorming process |
| `templates/plan-plus.template.md` | **New** | Enhanced plan template with brainstorming sections |
| `skills/pdca/SKILL.md` | **Modified** | Added tip referencing `/plan-plus` in plan section |

## Plan Plus Process Flow

```
Phase 0: Context Exploration (automatic)
    ↓
Phase 1: Intent Discovery (1 question at a time via AskUserQuestion)
    ↓
Phase 2: Alternatives Exploration (mandatory 2-3 approaches)
    ↓
Phase 3: YAGNI Review (multiSelect verification)
    ↓
Phase 4: Incremental Design Validation (section-by-section)
    ↓
Phase 5: Plan Document Generation (plan-plus.template.md)
    ↓
Phase 6: Next Steps → /pdca design {feature}
```

## Key Design Decisions

- **Separate skill, not modifying existing `/pdca plan`** — Preserves backwards compatibility; users opt-in to the enhanced workflow
- **HARD-GATE enforcement** — No code before plan approval, even for "simple" features
- **Feeds into standard PDCA** — Plan Plus output is identical to `/pdca plan` output; the rest of the PDCA cycle (design → do → analyze → report) works unchanged
- **8-language triggers** — Following bkit's multilingual convention (EN, KO, JA, ZH, ES, FR, DE, IT)

## Test Plan

- [ ] `/plan-plus user-auth` creates a Plan document at `docs/01-plan/features/user-auth.plan.md`
- [ ] All 6 phases execute in order with AskUserQuestion at each decision point
- [ ] HARD-GATE prevents code generation before plan approval
- [ ] Generated document includes User Intent, Alternatives, and YAGNI sections
- [ ] `/pdca design` works after `/plan-plus` completes (PDCA integration)
- [ ] Standard `/pdca plan` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)