### PR TITLE
fix: sync version to v2.1.1 + add qa-phase skill docs

### DIFF
--- a/commands/bkit.md
+++ b/commands/bkit.md
@@ -34,6 +34,7 @@ PDCA (Document-Driven Development)
   /pdca do <feature>         Implement with Checkpoint 4 (scope approval)
   /pdca do <feature> --scope module-N   Multi-session incremental (v2.0.5)
   /pdca analyze <feature>    Gap analysis with Checkpoint 5 (fix strategy)
+  /pdca qa <feature>         QA phase testing (L1-L5 test levels, v2.1.1)
   /pdca iterate <feature>    Auto-improvement iteration
   /pdca report <feature>     Generate completion report
   /pdca archive <feature>    Archive completed PDCA documents
@@ -56,6 +57,7 @@ Development Pipeline
 
 Quality Management
   /code-review <path>        Code review
+  /qa-phase <feature>        QA phase testing (L1-L5 test levels)
   /zero-script-qa            Start Zero Script QA
 
 Learning
@@ -85,7 +87,7 @@ Output Styles (v1.5.3)
 
 ## Functions Reference
 
-### User-Invocable Skills (12)
+### User-Invocable Skills (13)
 
 | Function | Description |
 |----------|-------------|
@@ -95,6 +97,7 @@ Output Styles (v1.5.3)
 | `/enterprise` | Enterprise project (K8s/Terraform) |
 | `/development-pipeline` | 9-phase development pipeline |
 | `/code-review` | Code quality analysis |
+| `/qa-phase` | QA phase testing with L1-L5 test levels |
 | `/zero-script-qa` | Log-based QA |
 | `/claude-code-learning` | Claude Code learning |
 | `/mobile-app` | Mobile app development (React Native/Flutter/Expo) |

--- a/hooks/session-start.js
+++ b/hooks/session-start.js
@@ -185,7 +185,7 @@ const sessionTitle = primaryFeature
   : undefined;
 
 const response = {
-  systemMessage: `bkit Vibecoding Kit v2.1.0 activated (Claude Code)`,
+  systemMessage: `bkit Vibecoding Kit v2.1.1 activated (Claude Code)`,
   hookSpecificOutput: {
     hookEventName: "SessionStart",
     onboardingType: onboardingContext.onboardingData.type,

--- a/hooks/startup/session-context.js
+++ b/hooks/startup/session-context.js
@@ -347,7 +347,7 @@ function build(_input, context) {
   const { onboardingData, triggerTable } = context;
   const detectedLevel = detectLevel();
 
-  let additionalContext = `# bkit Vibecoding Kit v2.1.0 - Session Startup\n\n`;
+  let additionalContext = `# bkit Vibecoding Kit v2.1.1 - Session Startup\n\n`;
 
   additionalContext += buildOnboardingContext(onboardingData);
   additionalContext += buildAgentTeamsContext(detectedLevel);


### PR DESCRIPTION
## Summary
- Fix version strings v2.1.0 → v2.1.1 in session-start hooks
- Add missing `/qa-phase` skill to bkit help (commands/bkit.md)
- Update user-invocable skills count 12 → 13

## Changed Files (3)
- `hooks/session-start.js` — activation message version
- `hooks/startup/session-context.js` — session header version  
- `commands/bkit.md` — qa-phase in PDCA flow, Quality Management, skills table

## Test plan
- [ ] `claude` launches with "v2.1.1" in SessionStart message
- [ ] `/bkit` shows `/qa-phase` in help output

🤖 Generated with [Claude Code](https://claude.com/claude-code)