### PR TITLE
fix: v2.1.3 version string hygiene (session-start.js + marketplace spec)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "bkit-marketplace",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "POPUP STUDIO's Vibecoding Kit marketplace - PDCA methodology and AI-native development tools",
   "owner": {
     "name": "POPUP STUDIO PTE. LTD.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **#67 — MCP `bkit_report_read` ignored `bkit.config.json docPaths`** — `servers/bkit-pdca-server/index.js` now loads `bkit.config.json` with an mtime-cached `loadBkitConfig()` helper and resolves `pdca.docPaths.{plan,design,analysis,report}` templates via `getPhaseTemplates()`. `docsPath()` walks the configured templates and returns the first existing file. All four doc-read tools (`bkit_plan_read`, `bkit_design_read`, `bkit_analysis_read`, `bkit_report_read`) honor custom config paths with fallback to built-in defaults for zero-config projects.
 
 ### Changed
-- **Version Sync** — `bkit.config.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `hooks/hooks.json` bumped to 2.1.3.
+- **Version Sync** — `bkit.config.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (both the marketplace spec version and the bkit plugin entry), `hooks/hooks.json`, and `hooks/session-start.js` systemMessage bumped to 2.1.3.
 - **Dead Constants Removed** — `servers/bkit-pdca-server/index.js` no longer declares `PHASE_MAP` / `DOCS_DIR` (both were superseded by the new template-based resolver).
 
 ### Documentation

--- a/hooks/session-start.js
+++ b/hooks/session-start.js
@@ -185,7 +185,7 @@ const sessionTitle = primaryFeature
   : undefined;
 
 const response = {
-  systemMessage: `bkit Vibecoding Kit v2.1.2 activated (Claude Code)`,
+  systemMessage: `bkit Vibecoding Kit v2.1.3 activated (Claude Code)`,
   hookSpecificOutput: {
     hookEventName: "SessionStart",
     onboardingType: onboardingContext.onboardingData.type,


### PR DESCRIPTION
## Summary

Follow-up to #69 (v2.1.3). Two hardcoded version strings were missed in the primary commit:

1. `hooks/session-start.js:188` — `systemMessage: "bkit Vibecoding Kit v2.1.2 activated (Claude Code)"` was still printing v2.1.2 on every session start, even though the release tag is v2.1.3.
2. `.claude-plugin/marketplace.json:4` — the marketplace spec `version` field was still `2.1.2`, out of sync with the bkit plugin entry at line 37.

## Verification

Full repo grep:
```bash
grep -rn "v2\.1\.2\|2\.1\.2" --include="*.js" --include="*.json" . | grep -v node_modules | grep -v ".bkit/"
```
After this PR, the only remaining hits are Claude Code version history references in `refs/CLAUDE-CODE-OFFICIAL-SOURCES.md` (CC v2.1.2 release notes — not bkit) and a test-case ID `2.1.2` in `bkit-system/testing/test-checklist.md` (not a version).

- [x] `node -c hooks/session-start.js` — OK

## Changes

- `hooks/session-start.js` — systemMessage bumped to v2.1.3
- `.claude-plugin/marketplace.json` — marketplace spec version bumped to 2.1.3
- `CHANGELOG.md` — [2.1.3] Changed bullet now explicitly lists session-start.js systemMessage + marketplace spec version

🤖 Generated with [Claude Code](https://claude.com/claude-code)