### PR TITLE
fix(ci): v2.1.19-hotfix.1 — check-deadcode regex + SqmPanel wiring + config opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.19-hotfix.1] - 2026-05-21 (branch: `feature/v2119-hotfix-1-deadcode`)
+
+> **Status**: CI hotfix — `Invocation Contract Check` workflow turned red immediately after v2.1.19 GA merge. The dead-code detector flagged 5 new v2.1.19 modules.
+> **Scope**: 4 files (+51 / -4). No feature behavior change — restores CI green, patches detector blind spot, closes one design/runtime wiring gap, and opts the new SQM dashboard section in via `bkit.config.json`.
+> **Root cause** (two independent issues coincided):
+> 1. `scripts/check-deadcode.js` require regex matched only direct string-literal forms (`require('./foo')`). The new v2.1.19 scripts use `require(path.join(ROOT, '...'))` (S0 measure, S3 docs-sync, S4 feedback refresh), so the detector treated their callees as orphaned.
+> 2. `lib/ui/sqm-panel.js` was specified by S5 design (ADR S5-003) to render in the SessionStart dashboard, but the wiring in `hooks/session-start.js` was never landed — a design/runtime gap. `bkit.config.json` `ui.dashboard.sections` also needed `'sqm'` for the new panel to opt in.
+
+### Fixed
+
+- **`scripts/check-deadcode.js`**: split `scanProductionRequires()` into two regexes. `reDirect` keeps the original behavior; `reIndirect` matches `require(<wrapper>(..., '<lib path>', ...))` where `<wrapper>` is any identifier (path.join, path.resolve, require.resolve, etc.) and the captured string literal contains `lib/` or starts with `./`/`../`. This restricts the new pattern to library-shaped references and avoids overmatching arbitrary strings. As a result `external-feedback-tracker`, `markdown-parse`, and `sqm-calculator` are correctly classified as live.
+- **`hooks/session-start.js`**: wired `lib/ui/sqm-panel` + `lib/quality/sqm-history` into the SessionStart dashboard. Added `'sqm'` to the default `_uiDashboardSections`. The render block is independent of the `primaryFeature` gate (SQM reflects project-wide quality maturity, not a single feature) and is fail-silent when `.bkit/state/sqm-history.jsonl` is missing. Closes the S5 design/runtime gap and makes `sqm-panel` + `sqm-history` live.
+- **`bkit.config.json`**: added `'sqm'` to `ui.dashboard.sections`. Without this, the runtime config (which takes precedence over the hook default) was a 5-section allowlist that excluded `'sqm'`, so the SqmPanel rendered to 0 chars even after wiring.
+
+### Verification
+
+- **`scripts/check-deadcode.js`**: NEW dead **5 → 0**, Live **134 → 139** (exactly the 5 intended modules — set-diff verified against the precise v2.1.19 GA baseline, NEW DEAD 0).
+- **Contract suite spot-check** (9 steps) all PASS: domain-purity (18 files) · guards (21 entries) · test-tracking (314 files, 0 untracked) · docs-code-sync (5/5 synced) · integration-runtime (23/23) · l2-smoke (101/101) · bkit-full-system (36/0/0) · contract-test-run vs v2.1.16 L1,L4 (255 assertions).
+- **Full QA aggregate** (4,168 TC, 157 test files): 12 FAIL + 6 errors reproduced identically against the HEAD~1 (v2.1.19 GA) baseline → confirmed pre-existing carryover (`ACTION_TYPES` baseline drift, trust-engine score change). **Hotfix introduced 0 new regressions.**
+- **SessionStart hook live run** (`CLAUDE_SESSION_ID=fresh node hooks/session-start.js`): JSON contract valid, all 5 dashboard sections including SQM (`64.00 / 100`) render correctly; `additionalContext` 5,482 → 5,741 chars (+259, SQM panel).
+
 ## [2.1.19] - 2026-05-21 (branch: `feature/v2119-quality-maturation`)
 
 > **Status**: Quality Maturation Sprint — pruge 가 v2.1.16~v2.1.18 cycle 에서 1.5일 / 10 issues 의 정밀한 결함 cluster (sprint domain) 를 보고. 단일 reactive fix loop 가 아닌 **5 sub-sprint master plan** 으로 sprint domain maturity 를 PDCA core 수준으로 격상. **모든 5 sub-sprint archived** + outer master sprint completion.

--- a/bkit.config.json
+++ b/bkit.config.json
@@ -8,7 +8,7 @@
     },
     "dashboard": {
       "enabled": true,
-      "sections": ["progress", "workflow", "impact", "agent", "control"]
+      "sections": ["progress", "workflow", "impact", "agent", "control", "sqm"]
     },
     "contextInjection": {
       "enabled": true,

--- a/hooks/session-start.js
+++ b/hooks/session-start.js
@@ -92,7 +92,7 @@ const dashboardSections = [];
 // When ui.dashboard.enabled=false, skip rendering all 5 boxes
 // (progress / workflow / impact / agent / control).
 let _uiDashboardEnabled = true;
-let _uiDashboardSections = ['progress', 'workflow', 'impact', 'agent', 'control'];
+let _uiDashboardSections = ['progress', 'workflow', 'impact', 'agent', 'control', 'sqm'];
 try {
   const { getUIConfig } = require('../lib/core/config');
   const _ui = getUIConfig();
@@ -235,6 +235,25 @@ if (pdcaStatus && pdcaStatus.primaryFeature && _uiDashboardEnabled) {
     if (controlPanel) dashboardSections.push(controlPanel);
   } catch (e) {
     debugLog('SessionStart', 'v2.0.0 control panel rendering failed', { error: e.message });
+  }
+}
+
+// 9. v2.1.19 S5 F5-2: SQM (Sprint Quality Maturity) panel
+// Rendered independently of primaryFeature gate — SQM reflects project-wide
+// quality maturity, not a single feature lifecycle. Fail-silent: when no
+// baseline measurement exists (.bkit/state/sqm-history.jsonl missing), the
+// panel renderer returns an empty string and is skipped.
+if (_uiDashboardEnabled && _uiDashboardSections.includes('sqm')) {
+  try {
+    const sqmHistory = require('../lib/quality/sqm-history');
+    const { renderSqmPanel } = require('../lib/ui/sqm-panel');
+    const baseline = sqmHistory.latest();
+    if (baseline) {
+      const sqmPanel = renderSqmPanel({ baseline });
+      if (sqmPanel) dashboardSections.push(sqmPanel);
+    }
+  } catch (e) {
+    debugLog('SessionStart', 'v2.1.19 SQM panel rendering failed', { error: e.message });
   }
 }
 

--- a/scripts/check-deadcode.js
+++ b/scripts/check-deadcode.js
@@ -92,6 +92,16 @@ function walk(dir) {
 
 function scanProductionRequires() {
   const refs = new Set();
+  // Pattern 1 (original): direct string-literal require — `require('./foo')` / `require("../lib/x.js")`
+  const reDirect = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+  // Pattern 2 (v2.1.19-hotfix.1): require wrapping path.join / require.resolve / path.resolve —
+  // captures any '...lib/...js' or '...lib/...' string literal inside the require call.
+  // Constrained to paths containing 'lib/' or starting with './'../' to limit false-positives.
+  // Examples covered:
+  //   require(path.join(ROOT, 'lib/quality/sqm-calculator.js'))
+  //   require(path.resolve(__dirname, '../lib/foo.js'))
+  //   require(require.resolve('./bar'))
+  const reIndirect = /require\s*\(\s*[a-zA-Z_$][\w.$]*\s*\([^)]*['"]((?:\.{1,2}\/|[^'"]*\blib\/)[^'"]+)['"][^)]*\)\s*\)/g;
   for (const r of PROD_ROOTS) {
     const root = path.join(PROJECT_ROOT, r);
     if (!fs.existsSync(root)) continue;
@@ -102,10 +112,12 @@ function scanProductionRequires() {
       } catch {
         continue;
       }
-      const re = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
       let m;
-      while ((m = re.exec(src)) !== null) {
+      while ((m = reDirect.exec(src)) !== null) {
         if (m[1].startsWith('.') || m[1].startsWith('/')) refs.add(m[1]);
+      }
+      while ((m = reIndirect.exec(src)) !== null) {
+        refs.add(m[1]);
       }
     }
   }


### PR DESCRIPTION
## Summary

CI hotfix for v2.1.19 GA. The `Invocation Contract Check` workflow turned red immediately after the v2.1.19 GA merge — the dead-code detector flagged 5 new v2.1.19 modules. This PR ships a precise fix for the underlying cause (detector blind spot + design/runtime wiring gap) with no behavior change to existing features.

## Root cause (two independent issues coincided)

1. **`scripts/check-deadcode.js`** — the require regex matched only direct string-literal forms (`require('./foo')`). The new v2.1.19 scripts use `require(path.join(ROOT, '...'))` (S0 measure, S3 docs-sync, S4 feedback refresh), so the detector treated their callees as orphaned.
2. **`hooks/session-start.js`** — `lib/ui/sqm-panel.js` was specified by S5 design (ADR S5-003) to render in the SessionStart dashboard, but the wiring was never landed. `bkit.config.json` `ui.dashboard.sections` also needed `'sqm'` for the new panel to opt in.

## Changes (4 files, +56 / -4)

| File | Change |
|------|--------|
| `scripts/check-deadcode.js` | Split `scanProductionRequires()` into `reDirect` + `reIndirect`. `reIndirect` matches `require(<wrapper>(..., '<lib path>', ...))` — restricted to library-shaped paths (contains `lib/` or starts with `./`/`../`) to avoid overmatching. |
| `hooks/session-start.js` | Wired `lib/ui/sqm-panel` + `lib/quality/sqm-history` into the SessionStart dashboard. Render block is independent of `primaryFeature` (SQM is project-wide) and fail-silent when `.bkit/state/sqm-history.jsonl` is missing. |
| `bkit.config.json` | Added `'sqm'` to `ui.dashboard.sections`. Runtime config takes precedence over the hook default, so without this the SqmPanel rendered to 0 chars even after wiring. |
| `CHANGELOG.md` | Added `[2.1.19-hotfix.1]` section. |

## User experience impact

- **Existing dashboard**: 4 sections (progress / workflow / impact / control) unchanged. Verified via live hook execution.
- **New section visible**: `┌─── SQM (Sprint Quality Maturity) ─── 64.00 / 100 ─┐` appears at the top of SessionStart context whenever `.bkit/state/sqm-history.jsonl` has at least one entry. Compact 4-line panel (~259 chars). Fail-silent when no baseline exists — zero impact on new projects.

## Verification

- [x] `scripts/check-deadcode.js`: NEW dead **5 → 0**, Live **134 → 139** (exactly the 5 intended modules — set-diff verified against the precise v2.1.19 GA baseline; NEW DEAD 0).
- [x] Contract suite 9-step spot-check all PASS: domain-purity (18) · guards (21) · test-tracking (314) · docs-code-sync (5/5) · integration-runtime (23/23) · l2-smoke (101/101) · bkit-full-system (36/0/0) · contract-test-run vs v2.1.16 L1,L4 (255 assertions).
- [x] Full QA aggregate (4,168 TC, 157 files): 12 FAIL + 6 errors reproduced identically against HEAD~1 (v2.1.19 GA) baseline — **0 new regressions** introduced by this hotfix. The 12 FAILs are pre-existing carryover (`ACTION_TYPES` baseline drift, trust-engine score change) that landed with v2.1.19 GA.
- [x] SessionStart hook live run with a fresh session id: JSON contract valid; all 5 dashboard sections including SQM (`64.00 / 100`) render correctly; `additionalContext` 5,482 → 5,741 chars (+259 for SQM panel).

## Test plan

- [ ] CI `Invocation Contract Check` workflow turns green on PR.
- [ ] After merge, the same workflow on `main` push also turns green.
- [ ] Tag `v2.1.19-hotfix.1` created and pushed.
- [ ] GitHub Release published with English notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
