### PR TITLE
fix(manifest): remove unrecognized 'displayName' key for Claude Code schema

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "bkit",
   "version": "2.1.20",
-  "displayName": "bkit — AI Native Development OS",
   "description": "The only Claude Code plugin that verifies AI-generated code against its own design specs.",
   "author": {
     "name": "POPUP STUDIO PTE. LTD.",


### PR DESCRIPTION
## Problem

`/plugin marketplace add popup-studio-ai/bkit-claude-code` fails on current Claude Code releases with:

```
Error: Failed to install: Plugin has an invalid manifest file at
 .claude-plugin/plugin.json.
 Validation errors: : Unrecognized key: "displayName"
```

## Root cause

`displayName` is an npm/VS Code-style field that is not part of the Claude Code plugin manifest schema. The schema rejects unknown top-level keys, so the package cannot be installed via the marketplace command.

## Fix

Remove the `displayName` line. `name` ("bkit") and `description` already provide identification for both the registry and the user-facing list.

## Test

After applying the change locally I was able to run `/plugin marketplace add <local-path>` without the validation error.

## Note

`outputStyles": "./output-styles/"` may also be a non-standard key — left in place for now; happy to send a follow-up if maintainers confirm it should map to a different schema field.