### PR TITLE
docs: CC version-impact reports + version-history memory + github-stats eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# bkit Project Rules
+
+## Language Rules
+
+### Conversation
+- Always respond in **Korean** (한국어) when communicating with the user.
+
+### Code & Documentation Language
+- **English by default** for ALL generated content:
+  - Code, comments, commit messages, PR descriptions
+  - README.md, CHANGELOG.md, and all non-docs/ markdown files
+  - Agent definitions (`agents/*.md`), skill definitions (`skills/*/SKILL.md`)
+  - Templates (`templates/*.md`)
+  - Config files, error messages, log messages
+
+- **Korean exceptions** (한국어 작성):
+  - `docs/` directory and all subdirectories (`docs/01-plan/`, `docs/02-design/`, `docs/03-analysis/`, `docs/04-report/`)
+  - 8-language auto-trigger keywords (EN, KO, JA, ZH, ES, FR, DE, IT) in agent/skill trigger lists
+  - bkit memory state descriptions in `.bkit/state/memory.json`
+
+### Key Principle
+bkit is a **global service**. Keep all public-facing and code-level content in English. Korean is only for internal planning docs (`docs/`) and developer communication.
+
+### Do NOT
+- Do NOT translate existing English files to Korean (waste of tokens)
+- Do NOT write docs/ files in English unless explicitly requested
+- Do NOT mix languages within a single file (except trigger keyword lists)
+
+## Sprint Management (v2.1.13)
+
+Sprint Management is a meta-container that groups one or more features under a
+shared scope, budget, and timeline. Each sprint runs its own 8-phase lifecycle:
+`prd → plan → design → do → iterate → qa → report → archived`.
+
+When the user mentions "sprint", invoke `bkit:sprint` skill (`/sprint <action>`).
+Sprint phases coexist with PDCA's 9-phase enum — both may track concurrently
+(see `docs/06-guide/sprint-migration.guide.md`).
+
+Trust Level scope (`SPRINT_AUTORUN_SCOPE`, L0–L4) controls auto-run boundaries.
+At L4 Full-Auto, the orchestrator advances phases until any of 4 auto-pause
+triggers fires (quality gate fail / iteration exhausted / budget exceeded /
+phase timeout).
+
+For deep-dive Korean guidance, see `docs/06-guide/sprint-management.guide.md`.

--- a/docs/04-report/features/cc-v2159-v2161-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2159-v2161-impact-analysis.report.md
@@ -1,0 +1,270 @@
+# CC v2.1.159 → v2.1.161 영향 분석 및 bkit 대응 보고서 (ADR 0003 열일곱 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 17번째 정식 적용, **17-cycle consistency milestone ✦**, 신규 ENH 0건 **13-cycle 연속**, **113 consecutive compatible milestone**, **2-version 소형 clean batch (49 bullets)**, Breaking 0건 / Breaking-equivalent 0건, 차별화 6/6 streak 갱신 (#56293→18 / #57317→12 / #58904→8), **OTEL 모니터 errata-trap 회피 (init-race fix ≠ shutdown-drop 모니터)**, R-2 skip 0건)
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (bkit.config.json + plugin.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst
+> **Date**: 2026-06-03
+> **PDCA Cycle**: cc-version-analysis (v2.1.159 → v2.1.161, **2-version 소형 batch** — 직전 v2.1.159 분석 이후 신규 v160/v161)
+> **CC Range**: v2.1.159 (baseline, internal-only) → **v2.1.161** (npm latest, 2026-06-02 21:58 UTC publish, installed=2.1.161)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking 0건 / Breaking-equivalent 0건 / 신규 ENH 0건 13-cycle 연속 / 차별화 6/6 streak 갱신 (#56293→18 / #57317→12 / #58904→8) / 113 consecutive milestone / OTEL 모니터 #64436 STAYS ACTIVE (errata-trap 회피) / 권장 CC v2.1.161 즉시 격상**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (v160/v161 Breaking 섹션 부재) |
+| **Breaking-equivalent** | **0건** — soft-breaking 후보 2건(v160 `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` no-op / `workflow`→`ultracode` rename)은 **bkit 참조 0건 실측 확인**되어 무영향 |
+| **bkit-friendly (auto-benefit)** | **5건** — v161 mcp 시크릿 redaction(보안) / v161 parallel-batch 실패 격리(robustness) / v161 bg subagent stdout 오염 fix(`-p` fan-out) / v161 Windows hook bash fix / v161 bg stale-model fix(frontmatter 정합) |
+| **out-of-scope (무영향)** | **다수** — Windows/WSL/IDE/vim/voice cosmetic 등 ~40 bullets |
+| **OTEL 모니터 #64436 처리** | **STAYS ACTIVE (errata-trap 회피)** — v161 "OTEL log dropped **before init**" fix는 bkit MON-CC-NEW-BG-OTEL-DROP("background **shutdown** OTEL drop")과 **반대 lifecycle**. 부주의하게 닫았다면 errata. `expectedFix: null` / `resolvedAt: null` 유지 |
+| **신규 ENH 후보** | **0건 (13-cycle 연속)** — ENH-329 후보 4건 모두 YAGNI DROP/REJECT |
+| 마지막 ENH 번호 | ENH-328 (DROP) — 본 cycle 신규 0건이므로 변동 없음 |
+| **차별화 6/6 streak 갱신** | **#56293 17→18 (ENH-292 P0) / #57317 11→12 (ENH-303 P1) / #58904 7→8 (ENH-310 P1)** — 49 bullets 중 3대 이슈 root cause 해결 0건, streak 연장. v161 parallel-batch 격리는 #57317 **인접하나 plugin-loader drop root cause 미해결** |
+| **#56293 상태 변화** | **CLOSED — not planned** (CC 미해결 확정). bkit Diff #3 (sequential dispatch)이 유일 mitigation으로 격상 |
+| **메모리 정정** | 없음 — bkit baseline(v2.1.22 / agents 40 / skills 44 / lib 190 modules 22 subdirs) 실측 일치, 차별화 surface 3/3 code-active 확인 |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (현재 main GA 안정, 113 consecutive milestone 입증) |
+| **연속 호환 릴리스** | **113 milestone** (v2.1.34 → v2.1.161, 112 → 113, +1 게시 batch — v160/v161 2버전, R-2 skip 0건) |
+| ADR 0003 적용 | **YES (17번째 정식 적용 — 17-cycle consistency milestone ✦)** |
+| **권장 CC 버전** | **v2.1.161 즉시 격상 권고** (보안 positive: mcp redaction + config-write prompts / robustness positive: parallel-batch 격리 + bg model 정합 / clean 49 bullets). **보수적 권장 stable v2.1.150 drift +11 CRITICAL band** → stable 격상 결정 권고 |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.159 → v2.1.161 영향 분석 (ADR 0003 17번째 ✦)      │
+│  ★ 2-version 소형 clean batch (49 bullets)               │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 49 bullets (verbatim 검증)             │
+│      v159(internal/0) v160(27) v161(22)                 │
+│      v160: Added 2 / Fixed 19 / Improved 3              │
+│            Removed 2 / Renamed 1                         │
+│      v161: 5 feature / 14 Fixed / 2 Improved / 1 VSCode │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking: 0건 / Breaking-equivalent: 0건             │
+│      • soft-breaking 2건 모두 bkit 참조 0건 실측          │
+│        - CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE no-op   │
+│        - workflow → ultracode trigger rename             │
+│  🟢 auto-benefit 5건                                     │
+│      • v161 mcp 시크릿 redaction (보안)                  │
+│      • v161 parallel-batch 실패 격리 (robustness)        │
+│      • v161 bg subagent stdout 오염 fix (-p fan-out)     │
+│      • v161 Windows hook bash fix                        │
+│      • v161 bg stale-model fix (frontmatter 정합)        │
+│  🆕 신규 ENH 후보: 0건 (13-cycle 연속)                  │
+│      ENH-329 후보 4건 모두 YAGNI DROP/REJECT             │
+│  ⚠️ errata-trap 회피 (핵심):                             │
+│      v161 "OTEL drop before init" fix ≠                  │
+│      bkit MON-CC-NEW-BG-OTEL-DROP (shutdown drop)        │
+│      → 반대 lifecycle, 모니터 STAYS ACTIVE               │
+│      (부주의하게 닫았다면 errata 발생)                   │
+│  🟢 #56293 caching 10x 17→18-streak (ENH-292 P0)        │
+│      ★ CLOSED-not-planned → bkit Diff #3 유일 mitigation │
+│  🟢 #57317 PostToolUse drop 11→12-streak (ENH-303 P1)   │
+│      v161 parallel 격리 인접하나 root cause 미해결       │
+│  🟢 #58904 heredoc bypass 7→8-streak (ENH-310 P1)       │
+│      v160 config-write prompt이 pipe-target gap 미커버   │
+│  📉 R-2 true skip: 0건 (v160/v161 triple-present)        │
+│  📉 R-3: v161 forceLoginOrgUUID = v146 regression 복구   │
+│      (15-version 지연 복구, same-day chain 아님)         │
+│  ⚠️ drift (보수적) stable v2.1.150 ↔ installed v2.1.161  │
+│      = +11 CRITICAL band → stable 격상 결정 권고         │
+│  ✅ 연속 호환 릴리스: 112 → 113 milestone (+1 batch)     │
+│  ✅ ADR 0003 17-cycle consistency milestone ✦           │
+│  ✅ Phase 1.5 게이트: v161 under-count(21) 차단          │
+│      VSCode bullet 누락 → raw 22 확정 (v145 패턴 재현)   │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 전달된 가치
+
+| 관점 | 내용 |
+|------|------|
+| **문제** | CC CLI가 직전 분석(v2.1.159) 이후 **2개 신규 버전(v160/v161)** 게시 — config-write 보안 prompt + parallel-batch 격리 + dynamic-workflow 키워드 rename + OTEL drop fix 등 49 bullets. bkit v2.1.22 호환성, soft-breaking 2건의 실제 영향, 차별화 6/6 moat 유효성, OTEL fix의 모니터 영향 평가 필요. |
+| **해결 방법** | ADR 0003 정식 적용 (17번째 cycle) — Phase 1 (cc-version-researcher 2-version 조사) + Phase 1.5 (raw verification gate, v161 under-count 차단) + Phase 2 (bkit-impact-analyst 실측 + Numeric Correction Protocol + errata-trap 검증) + Phase 3 (Plan Plus YAGNI) + Phase 4 (보고서) 5-Phase 분석 |
+| **결과 — Breaking-equivalent 0건 (soft-breaking 실측 무효화)** | soft-breaking 후보 2건 모두 bkit 참조 0건 실측: ① `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` no-op화 → bkit 코드/문서/hook 참조 **0건** (정리 불필요), ② dynamic-workflow 트리거 `workflow`→`ultracode` rename → bkit skill/agent의 CC-trigger 의존 **0건** (서술적 사용만, 무영향). bkit이 CC env/trigger에 hard-coupling하지 않은 설계가 정당화. |
+| **결과 — auto-benefit 5건** | v161의 보안·robustness fix가 bkit에 무수정 수혜: mcp 시크릿 redaction(2 MCP servers 보안), parallel-batch 실패 격리(Diff #3/#5 robustness 보강), bg subagent stdout 오염 fix(40-agent `-p` fan-out 보호), Windows hook bash fix(hook 신뢰성), bg stale-model fix(40/40 agent `model:` frontmatter 정합). |
+| **결과 — OTEL 모니터 errata-trap 회피 (핵심)** | v161 "OpenTelemetry log events silently dropped **when emitted before telemetry init**" fix는 bkit MON-CC-NEW-BG-OTEL-DROP(#64436, "background sessions drop OTEL logs **on shutdown**")과 **lifecycle 반대 끝**(init-race vs shutdown-flush). `lib/infra/telemetry.js`에 shutdown/flush/beforeExit handler **0개**(grep 확인) → bkit는 이 fix와 상호작용하는 flush 경로 없음. **모니터 STAYS ACTIVE**(`expectedFix: null`). 부주의한 "OTEL fixed" 독해 시 모니터를 잘못 닫는 errata 발생 가능했음 — **No Guessing 원칙으로 차단**. |
+| **결과 — 신규 ENH 0건 13-cycle 연속** | ENH-329 후보 4건 모두 reject: OTEL 모니터 resolved 표기(errata) / bg-frontmatter-model 모니터(auto-benefit로 충분) / parallel-batch 격리 dispatcher 활용(moat #3와 orthogonal — moat은 cache cost, fix는 failure isolation) / config-write-prompt hook 인지(bkit가 guarded path 미작성). **13-cycle 연속 신규 ENH 0건** = bkit 아키텍처 성숙도 지속 입증. |
+| **결과 — 차별화 6/6 streak 갱신** | v160/v161 어떤 bullet도 #56293/#57317/#58904를 해결하지 않음. #56293 **17→18** (ENH-292, **CLOSED-not-planned로 bkit Diff #3가 유일 mitigation 격상**), #57317 **11→12** (ENH-303, v161 parallel 격리 인접하나 plugin-loader drop root cause 미해결), #58904 **7→8** (ENH-310, v160 config-write prompt이 heredoc pipe-target gap 미커버). 3 surface 모두 code-active 실측. |
+| **결과 — Phase 1.5 게이트 정상 작동** | cc-version-researcher 첫 model-fetch가 v161을 **21로 under-count**(trailing `[VSCode]` bullet 누락) — v2.1.16/v2.1.145 errata 패턴 재현. 메인 세션 raw CHANGELOG + GitHub release tag 이중 fetch가 **22 확정**, raw wins로 차단. |
+| **핵심 가치** | bkit v2.1.22 무수정 **113 consecutive milestone** + ADR 0003 **17-cycle consistency ✦** + **OTEL errata-trap 회피**(init-race fix를 shutdown-drop 모니터로 오인하지 않음 — No Guessing 실증) + soft-breaking 2건 무효화(env/trigger hard-coupling 없음 입증) + 차별화 6/6 streak 갱신 = **product moat + 분석 방법론 신뢰성 동시 입증 cycle** |
+| **검증 데이터** | 사용자 환경 실증 (Darwin 24.6.0 / `claude --version` = **2.1.161** / bkit.config.json = **2.1.22** / agents **40** (`model:` 40/40) / skills **44** / lib **190 modules 22 subdirs** / MCP **2 servers** / OPUS_4_6_FAST env 참조 **0** / ultracode 참조 **0** / read-before-edit lib 의존 **0** / 차별화 surface 3/3 code-active: sub-agent-dispatcher.js + unified-bash-post.js:101,160 + heredoc-detector.js / telemetry.js shutdown handler **0**) |
+
+---
+
+## 2. 관련 문서
+
+| Phase | 문서 | 상태 |
+|-------|------|------|
+| Research (Phase 1) | CC v2.1.159→v2.1.161 변경사항 조사 (cc-version-researcher 백그라운드 에이전트, 4-source 교차 검증) | ✅ Done (in-memory) |
+| Raw Verification (Phase 1.5) | Raw CHANGELOG.md + GitHub release tag(v160/v161) 직접 fetch (메인 세션, v161 under-count 21→22 차단) | ✅ Done (49 verbatim 확정) |
+| Impact Analysis (Phase 2) | bkit 영향 분석 (bkit-impact-analyst 백그라운드 에이전트 + main session 실측 grep + Numeric Correction Protocol + OTEL errata-trap 검증) | ✅ Done |
+| Brainstorm (Phase 3) | Plan Plus YAGNI + Priority Assignment (main session 자체 수행) | ✅ Done |
+| Report (Phase 4) | 본 문서 | ✅ Final |
+| Memory | [cc_version_history_v2160_v2161.md](../../../memory/cc_version_history_v2160_v2161.md) | ✅ Created |
+| 직전 cycle | [cc-v2146-v2159-impact-analysis.report.md](./cc-v2146-v2159-impact-analysis.report.md) | 참조 (streak baseline 17/11/7) |
+
+---
+
+## 3. CC 변경사항 분석 (Phase 1 + Phase 1.5)
+
+### 3.0 Verification Notes (Phase 1.5 게이트 결과)
+
+| Field | Agent reported (1차 fetch) | Raw verified | Source URL | Verdict |
+|-------|---------------------------|--------------|------------|---------|
+| v160 Total | 27 | **27** | raw CHANGELOG + release tag v2.1.160 | **match** |
+| v161 Total | 21 (under-count) | **22** | raw CHANGELOG + release tag v2.1.161 | **errata 차단** (VSCode bullet 누락) |
+| v159 | internal | **0 (internal)** | CHANGELOG header | match |
+| **합계** | 48 | **49** | sum | **errata 차단 → 49 확정** |
+
+- **errata 근거**: cc-version-researcher 첫 model-processed fetch가 v161을 "Added 4 / Improved 3 / Fixed 14 = 21"로 집계하며 trailing `[VSCode] Added a tip ...` bullet을 누락. 메인 세션 raw CHANGELOG.md + GitHub release tag 이중 fetch가 **22** 확인. **raw wins**. (v2.1.16/v2.1.145 under-count 패턴의 3번째 재현.)
+- **spot-check ≥3 verbatim 확인**: v160 #1(shell startup prompt) / v160 Renamed(workflow→ultracode) / v161 #14(mcp secret redaction) 모두 raw와 일치.
+- **R-2 skip 0건**: v160/v161 모두 npm version object + GitHub tag + CHANGELOG header **triple-present**.
+
+### 3.1 v2.1.160 핵심 변경 (27 bullets: Added 2 / Fixed 19 / Improved 3 / Removed 2 / Renamed 1)
+
+| 분류 | bullet (verbatim 요약) | Impact | bkit 관련 | 판정 |
+|------|----------------------|:---:|:---:|------|
+| Added/Security | shell startup files(.zshenv/.zlogin/.bash_login) + ~/.config/git/ 쓰기 전 prompt | HIGH | YES | bkit guarded path 아님 → **neutral** |
+| Added/Security | acceptEdits build-tool config(.npmrc/.yarnrc*/bunfig.toml/.bazelrc/.pre-commit-config.yaml/.devcontainer/) 쓰기 전 prompt | HIGH | YES | bkit 미작성 path → **neutral** (#58904 heredoc gap 미커버) |
+| Fixed | grep 후 별도 Read 불필요 (single-file grep/egrep/fgrep read-before-edit 충족) | MEDIUM | YES | bkit lib read-before-edit 의존 **0건** → **neutral/auto** |
+| Removed/soft-breaking | `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` no-op | MEDIUM | YES(check) | bkit 참조 **0건** → **무영향** |
+| Renamed/soft-breaking | dynamic-workflow 트리거 `workflow` → `ultracode` (violet highlight) | MEDIUM | YES(check) | bkit CC-trigger 의존 **0건** → **무영향** |
+| Fixed × 16 | Windows/WSL/IME/voice/vim/scrollback/auto-mode/SDK cosmetic | LOW | NO | **out-of-scope** |
+| Improved × 3 | bg session 열기 perf / auto-mode classifier latency / SIGTERM-before-SIGKILL teardown | LOW | NO | **out-of-scope** |
+
+### 3.2 v2.1.161 핵심 변경 (22 bullets)
+
+| 분류 | bullet (verbatim 요약) | Impact | bkit 관련 | 판정 |
+|------|----------------------|:---:|:---:|------|
+| Feature/Tool | Parallel tool calls: 실패 Bash가 같은 batch의 다른 call을 더 이상 취소 안 함 | HIGH | YES | Diff #3/#5 robustness 보강 → **auto-benefit** |
+| Fixed/Security(MCP) | `claude mcp` list/get/add 시크릿 redaction (`${VAR}` 미확장, credential 가림) | MEDIUM | YES | 2 MCP servers 보안 → **auto-benefit** |
+| Fixed | bg subagent output이 `claude -p` stdout(`--output-format text/json`) 오염 fix | MEDIUM | YES | 40-agent `-p` fan-out 보호 → **auto-benefit** |
+| Fixed/Hook | Windows hook이 bash 명시 호출 시 실패 fix | MEDIUM | YES | hook 신뢰성(Darwin primary, Windows 수혜) → **auto-benefit** |
+| Fixed/Config | bg session이 daemon env의 stale model로 부팅 → settings.json model fix | MEDIUM | YES | 40/40 agent `model:` frontmatter 정합 → **auto-benefit** |
+| Fixed/Config | **OTEL log events(`user_prompt`/`api_request`/`tool_result`/`tool_decision`) init 완료 전 emit 시 silent drop fix** | LOW | NO(indirect) | **MON-CC-NEW-BG-OTEL-DROP과 반대 lifecycle → 모니터 STAYS ACTIVE** |
+| Feature | OTEL_RESOURCE_ATTRIBUTES → metric datapoint label / claude agents done/total / /mcp unused connector collapse / fullscreen clipboard | LOW~MED | NO | indirect |
+| Fixed × 9 | /effort dialog reduce-motion / forceLoginOrgUUID(v146 regr) / /usage-credits / /autofix-pr / --resume picker / Workflow worktree isolation / Write crash / subagent stuck-running / EADDRINUSE | LOW~MED | 대부분 NO | **out-of-scope / indirect** |
+| Improved × 2 + VSCode | terminal JIT perf / large file write perf / [VSCode] GPU accel tip | LOW | NO | **out-of-scope** |
+
+---
+
+## 4. bkit 영향 분석 (Phase 2)
+
+### 4.1 차별화 surface 검증 (3/3 code-active)
+
+| Diff | surface 파일 | 실측 evidence | streak |
+|------|-------------|--------------|:---:|
+| #3 Sequential Dispatch | `lib/orchestrator/sub-agent-dispatcher.js` | header "bkit moat #3 — sequential dispatch policy enforcement", FSM FIRST_SPAWN_SEQUENTIAL | #56293 → **18** |
+| #5 PostToolUse continueOnBlock | `scripts/unified-bash-post.js:101,160` | "ENH-303: emit hookSpecificOutput with continueOnBlock=true" | #57317 → **12** |
+| #6 Heredoc immunity | `lib/defense/heredoc-detector.js` | 파일 존재 확인, ENH-310 | #58904 → **8** |
+
+직전 authoritative streak 17/11/7 (`memory/cc_version_history_v2147_v2159.md:59-61`). 본 batch 3대 이슈 root cause 해결 0건 → 전부 +1 = **18/12/8**.
+
+### 4.2 OTEL 모니터 errata-trap 상세 (No Guessing 실증)
+
+| | bkit MON-CC-NEW-BG-OTEL-DROP (#64436) | v161 OTEL fix |
+|--|--|--|
+| 정의 | background session이 work-phase OTEL log를 **shutdown 시** drop (`lib/cc-regression/registry.js:160-169`) | OTEL log가 **telemetry init 완료 전** emit 시 drop |
+| lifecycle phase | shutdown-time loss (flush 실패) | init-time race (startup 순서) |
+| issue 귀속 | #64436 | researcher가 #64436으로 귀속하지 않음 |
+| bkit flush 경로 | `lib/infra/telemetry.js` shutdown/flush/beforeExit handler **0개** (grep 확인) | — |
+
+**판정**: 두 fix는 session lifecycle의 **반대 끝**. v161 fix는 startup ordering race를 닫고, bkit 모니터는 background shutdown drop을 추적. **모니터 STAYS ACTIVE** (`expectedFix: null`, `resolvedAt: null`). 부주의한 "OTEL drop fixed" 독해 시 모니터 오종결 errata 발생 가능했음 → **검증으로 차단**.
+
+### 4.3 항목별 영향 요약
+
+| 항목 | CC 변경 | bkit touchpoint | 분류 |
+|------|---------|-----------------|------|
+| #1/#2 | config-write 보안 prompt | bkit `docs/`/`.bkit/state/`/`templates/`만 작성 (guarded path 미작성) | **neutral** |
+| #5(v160) | grep→edit read-before-edit 완화 | lib/scripts/agents read-before-edit 의존 0건 | **neutral/auto** |
+| #4(v161) | parallel Bash 실패 격리 | sub-agent-dispatcher.js + unified-bash-post.js | **auto-benefit** (moat #3와 orthogonal) |
+| #7(v161) | bg subagent stdout 오염 fix | 40-agent `-p` fan-out | **auto-benefit** |
+| #8(v161) | Windows hook bash fix | hooks/scripts (Darwin primary) | **neutral** (Windows 수혜) |
+| #9(v161) | mcp 시크릿 redaction | 2 MCP servers | **auto-benefit (보안)** |
+| #11(v161) | worktree-isolation bg agent fix | cto-lead.md:290 (서술적) | **neutral** (코드 경로 없음) |
+| #12(v161) | bg stale-model fix | 40/40 agent `model:` frontmatter | **auto-benefit/neutral** |
+
+---
+
+## 5. Plan Plus 브레인스토밍 (Phase 3)
+
+### 5.1 Intent Discovery
+
+| 질문 | 답변 |
+|------|------|
+| 이 업그레이드에서 bkit 최대 가치? | **113 consecutive milestone** + 차별화 6/6 streak 갱신(#56293 CLOSED-not-planned로 Diff #3 유일 mitigation 격상) + **OTEL errata-trap 회피**(No Guessing 실증) + v161 보안/robustness auto-benefit 5건 |
+| 놓치면 안 되는 critical change? | **없음** — 모든 bkit-relevant bullet이 auto-benefit 또는 out-of-scope. soft-breaking 2건은 실측 무영향 |
+| workaround 대체 native 기능? | **없음** — v161 parallel-batch 격리는 Diff #3(cache cost)와 orthogonal(failure isolation). moat 대체 아님 |
+
+### 5.2 YAGNI Review (ENH-329 후보 4건 전부 reject)
+
+| 후보 | YAGNI 테스트 | 판정 |
+|------|------------|------|
+| ENH-329: OTEL 모니터 #64436 resolved 표기 | 무엇이 깨지나? 모니터 오종결(반대 lifecycle) → errata | **REJECT (errata)** |
+| ENH-329: bg-frontmatter-model 모니터 추가 | 없으면 무엇이? 무영향(frontmatter honored, 버그 클래스 upstream fix) | **DROP** (auto-benefit 충분) |
+| ENH-329: parallel-batch 격리 dispatcher 활용 | 다음 CC가 더 잘? 이미 native 처리. moat #3은 cache cost로 orthogonal | **DROP** |
+| ENH-329: config-write-prompt hook 인지(#1/#2) | bkit가 guarded path 미작성 | **DROP** |
+
+**최종 결정**: **신규 ENH 0건 (13-cycle 연속)**.
+
+### 5.3 Priority Assignment
+
+| Priority | 항목 | 시점 |
+|:---:|------|------|
+| **P1** | **권장 CC v2.1.161 즉시 격상** (보안 + robustness positive + clean 49 bullets) | 즉시 |
+| **P1** | **보수적 권장 stable v2.1.150 격상 결정** (drift +11 CRITICAL band) | 즉시 |
+| **P2** | 차별화 streak 18/12/8 + OTEL 모니터 active 기록 (memory) | 본 cycle |
+| **P3** | (없음) | — |
+
+---
+
+## 6. 최종 판정 및 권고
+
+### 6.1 종합 verdict
+
+| Metric | Value |
+|--------|-------|
+| Critical regressions | **0** |
+| Breaking changes | **0** |
+| Breaking-equivalent | **0** (soft-breaking 2건 실측 무영향) |
+| New ENH | **0** (13-cycle consecutive-0 streak) |
+| Differentiator streaks | #56293 → **18**, #57317 → **12**, #58904 → **8** (전부 OPEN, moat 3/3 code-active) |
+| OTEL 모니터 #64436 | **STAYS ACTIVE** (init-race fix ≠ shutdown-drop 모니터) |
+| Consecutive compatible milestone | 112 → **113** (v2.1.34 ~ v2.1.161) |
+| Recommended CC version | **v2.1.161** (clean, 보안 positive, robustness positive) |
+
+### 6.2 권고 액션
+
+| # | 액션 | Priority | 시점 |
+|:---:|------|:---:|------|
+| 1 | **CC v2.1.161 즉시 격상** (mcp redaction + parallel 격리 + bg model 정합) | P1 | 즉시 |
+| 2 | **보수적 권장 stable v2.1.150 격상 결정** (drift +11) | P1 | 즉시 |
+| 3 | 차별화 streak 18/12/8 + #56293 CLOSED-not-planned 기록 | P2 | 본 cycle |
+| 4 | OTEL 모니터 #64436 active 유지 (errata-trap 회피 기록) | P2 | 본 cycle |
+| 5 | 신규 ENH 0건 / 코드 변경 0건 / 신규 TC 0건 | — | — |
+
+### 6.3 테스트 영향
+
+| 항목 | 값 | 비고 |
+|------|----|----|
+| 코드 변경 | **0건** | 무수정 113 consecutive milestone |
+| 새 테스트 추가 | **0건** | 기존 guard(registry.js OTEL 모니터, 차별화 surface) 유효 |
+| 회귀 위험 | **없음** | bkit v2.1.22 무수정 작동 |
+
+---
+
+## 7. 학습 및 다음 cycle 참고
+
+- **errata-trap 패턴 신규 발견**: "동일 키워드(OTEL) fix"가 bkit 모니터를 자동 해소하는 것처럼 보여도 **lifecycle phase(init-race vs shutdown-flush)가 다르면 미해소**. 다음 cycle에서도 fix↔monitor 매칭 시 phase 단위 대조 필수.
+- **soft-breaking 실측 패턴**: env var no-op / trigger rename은 항상 bkit 참조 grep으로 실제 영향 확정 (이번에도 둘 다 0건).
+- **Phase 1.5 게이트 효용 재입증**: 소형 batch에서도 model-fetch under-count(v161 21→22, VSCode bullet 누락) 발생 → raw 이중 fetch 필수.
+- **#56293 CLOSED-not-planned**: CC가 caching 10x를 미해결 확정 → bkit Diff #3가 영구 moat로 격상. 다음 cycle에서 streak는 계속 증가하나 "해결 대기"가 아닌 "영구 차별화"로 해석.
+- **다음 baseline**: v2.1.161. 다음 분석은 v2.1.162부터.

--- a/docs/04-report/features/cc-v2161-v2162-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2161-v2162-impact-analysis.report.md
@@ -1,0 +1,222 @@
+# CC v2.1.161 → v2.1.162 영향 분석 및 bkit 대응 보고서 (ADR 0003 열여덟 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 18번째 정식 적용, **18-cycle consistency milestone ✦**, 신규 ENH 0건 **14-cycle 연속**, **114 consecutive compatible milestone**, **1-version 소형 clean delta (28 bullets)**, Breaking 0건 / Breaking-equivalent 0건, 차별화 6/6 streak 갱신 (#56293→19 / #57317→13 / #58904→9), **OTEL 모니터 STAYS ACTIVE (v162 OTEL bullet 0건)**, Phase 1.5 게이트 under-count trap 회피 (researcher 27 → raw 28), R-2 skip 0건)
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (bkit.config.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst
+> **Date**: 2026-06-05
+> **PDCA Cycle**: cc-version-analysis (v2.1.161 → v2.1.162, **1-version 소형 delta** — 직전 v2.1.161 분석 이후 신규 v162)
+> **CC Range**: v2.1.161 (baseline) → **v2.1.162** (npm latest, 2026-06-03 21:31 UTC publish @ashwin-ant, installed=2.1.162)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking 0건 / Breaking-equivalent 0건 / 신규 ENH 0건 14-cycle 연속 / 차별화 6/6 streak 갱신 (#56293→19 / #57317→13 / #58904→9) / 114 consecutive milestone / OTEL 모니터 #64436 STAYS ACTIVE / 권장 CC v2.1.162 즉시 격상**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (v162 Breaking 섹션 부재, flat list 28 bullets) |
+| **Breaking-equivalent** | **0건** — soft-breaking 후보 6건(#2 `--tools` Grep/Glob native / #6 Windsurf→Devin rename / #8 WebFetch 도메인 규칙 precedence / #9 Windows 권한·Read deny / #12 MCP timeout <1000ms / #28 startup 메시지 제거)은 **bkit 부착점 0건 실측 확인**되어 무영향 |
+| **bkit-friendly (auto-benefit)** | **4건** — #8 WebFetch deny/ask/allow precedence(보안) / #9 Windows 권한 매칭 + Read deny→Glob/Grep 숨김(보안) / #11 emoji/surrogate API-400 fix(MCP desc) / #26 bg-service startup + `claude update` EDR-scan 대기(robustness) |
+| **out-of-scope (무영향)** | **다수** — `claude agents` TUI / startup 메시지 / autocomplete / LSP 등 ~15 bullets |
+| **OTEL 모니터 #64436 처리** | **STAYS ACTIVE** — v162 OTEL 관련 bullet **0건**. `expectedFix: null` / `resolvedAt: null` 유지 (v161 init-race fix와 무관, shutdown-flush drop 모니터 그대로) |
+| **신규 ENH 후보** | **0건 (14-cycle 연속)** — ENH-329 후보 3건(#2/#9/#12) 모두 YAGNI DROP/REJECT |
+| 마지막 ENH 번호 | ENH-328 (DROP) — 본 cycle 신규 0건이므로 변동 없음, ENH-329 미소비 |
+| **차별화 6/6 streak 갱신** | **#56293 18→19 (ENH-292 P0) / #57317 12→13 (ENH-303 P1) / #58904 8→9 (ENH-310 P1)** — 28 bullets 중 3대 이슈 root cause 해결 0건, streak 연장 |
+| **메모리 정정** | 없음 — bkit baseline 6/6 항목 직접 재측정 일치 (v2.1.22 / agents 40 (model: 40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2 servers) |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (현재 main GA 안정, 114 consecutive milestone 입증) |
+| **연속 호환 릴리스** | **114 milestone** (v2.1.34 → v2.1.162, 113 → 114, +1 게시 — v162 1버전, R-2 skip v134/135/151/155 제외) |
+| ADR 0003 적용 | **YES (18번째 정식 적용 — 18-cycle consistency milestone ✦)** |
+| **권장 CC 버전** | **v2.1.162 즉시 격상 권고** (보안 positive: WebFetch precedence + Windows 권한 정확성 / robustness positive: bg-service startup + read-only config 복원력 / clean 28 bullets). **보수적 권장 stable v2.1.152 drift +10 CRITICAL band** → stable 격상 결정 권고 |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.161 → v2.1.162 영향 분석 (ADR 0003 18번째 ✦)      │
+│  ★ 1-version 소형 clean delta (28 bullets)               │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 28 bullets (verbatim 검증, flat list)  │
+│      Added-type 6 / Fixed 15 / Improved·Removed 7        │
+│  🔍 Phase 1.5 게이트: researcher 27 → raw 28 (under-     │
+│      count trap 회피, raw CHANGELOG=GitHub tag identical) │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking: 0건 / Breaking-equivalent: 0건             │
+│      • soft-breaking 6건 모두 bkit 부착점 0건 실측        │
+│        - #2 --tools Grep/Glob native (agent tools 무관)  │
+│        - #6 Windsurf → Devin Desktop rename             │
+│        - #8 WebFetch domain rule precedence             │
+│        - #9 Windows 권한 + Read deny                     │
+│        - #12 MCP per-server timeout <1000ms             │
+│        - #28 startup 메시지 제거                          │
+│  🟢 auto-benefit 4건                                     │
+│      • #8 WebFetch deny/ask/allow precedence (보안)     │
+│      • #9 Windows 권한 매칭 + Read deny 숨김 (보안)      │
+│      • #11 emoji/surrogate API-400 fix (MCP desc)       │
+│      • #26 bg-service startup EDR-scan 대기 (robust)    │
+│  🆕 신규 ENH 후보: 0건 (14-cycle 연속)                  │
+│  📈 차별화 6/6 streak: #56293→19 #57317→13 #58904→9    │
+│  ✅ 연속 호환: 114 milestone (v2.1.34~v2.1.162)         │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 4-Perspective 가치 평가
+
+| 관점 | 평가 | 근거 |
+|------|------|------|
+| **사용자(User)** | ⬆ 개선 | bg-session 데이터 손실 fix(#18/#19), read-only config startup 복원(#7), startup 노이즈 감소(#22~25,#28) → 안정성·가독성 향상 |
+| **개발자(Dev/bkit)** | ⟷ 무영향 | bkit 소스 변경 0건, hook/agent/skill 스키마 변경 없음, 14-cycle 연속 무수정 |
+| **보안(Security)** | ⬆ 개선 | #8 WebFetch 권한 precedence(권한 우회 클래스 하드닝), #9 Windows deny-rule 회피 fix → bkit Defense layer 하부 권한 계층 자동 강화 |
+| **운영(Ops)** | ⬆ 개선 | #26 EDR-scan 대기로 `claude update` 실패 감소, #20 TMPDIR deep-path SendMessage fix → CI/원격 환경 안정성 |
+
+---
+
+## 2. CC v2.1.162 변경사항 (28 bullets, raw-verified)
+
+### 2.1 Phase 1.5 Raw Verification Gate 결과
+
+| Field | Agent 보고 | Raw 검증 | Source URL | Verdict |
+|-------|:---:|:---:|------|:---:|
+| Added-type | 6 | 6 | 분류(소스 sub-heading 부재) | match |
+| Fixed | 15 | 15 | 분류 | match |
+| Improved·Removed | 7 (자가수정) | 7 | 분류 | match |
+| **Total bullets** | **27 → 28** | **28** | raw CHANGELOG = GitHub tag (byte-identical) | **errata 회피 (raw wins)** |
+
+- **under-count trap 회피**: cc-version-researcher 초기 27 miscount → 메인 세션 raw CHANGELOG.md + GitHub release tag 이중 fetch로 **28 확정**. v2.1.16/v2.1.145/v2.1.161에 이은 4번째 under-count 패턴 재현 → 게이트 효용 재입증.
+- **구조**: v162 CHANGELOG는 sub-heading 없는 **flat list**. Added/Fixed/Improved 분류는 선행 동사 기반 분류이며 소스 명시값 아님.
+- **게시자 정정**: npm `_npmUser`=wolffiex / GitHub release author=**@ashwin-ant** — 양립(npm publish ≠ GitHub author). 게시 2026-06-03 21:31 UTC.
+- **spot-check 3건**(#8/#12/#20) raw 양 소스 verbatim 일치 확인.
+
+### 2.2 카테고리별 분류
+
+| 그룹 | bullets | 핵심 항목 |
+|------|:---:|------|
+| Added-type (6) | 1~6 | `claude agents --json waitingFor`, `--tools` Grep/Glob native, `/effort` persist 확인, slash autocomplete fill, Remote Control footer pill, Windsurf→Devin rename |
+| Fixed (15) | 7~21 | read-only config startup hang, WebFetch 권한 precedence, Windows 권한·Read deny, Esc interrupt drop, emoji surrogate API-400, MCP timeout <1000ms, LSP workspaceSymbol, `claude agents` TUI 다수, bg-session 손실/큐잉, SendMessage TMPDIR, bg 5s stall |
+| Improved·Removed (7) | 22~28 | quieter startup, warnings 재작성/pinned, compact 실패 turn, bg-service EDR-scan 대기, dispatch spawn error-class, startup 메시지 제거 |
+
+---
+
+## 3. bkit 영향 분석
+
+### 3.0 아키텍처 베이스라인 직접 재측정 (Numeric Correction Protocol)
+
+| 항목 | 측정값 | 측정 명령 | 이전 메모리 | 판정 |
+|------|:---:|------|:---:|:---:|
+| agents | 40 | `Glob agents/*.md` | 40 | 일치 |
+| model: 커버리지 | 40/40 | `Grep "^model:" agents/` | 40/40 | 일치 |
+| skills | 44 | `Glob skills/*/SKILL.md` | 44 | 일치 |
+| lib modules | 190 | `Grep "module.exports" lib/` | 190 | 일치 |
+| lib subdirs | 22 | 경로 distinct top-level 추출 | 22 | 일치 |
+| MCP servers | 2 | `Glob servers/**/index.js` | 2 | 일치 |
+| bkit version | 2.1.22 | `Read bkit.config.json` | 2.1.22 | 일치 |
+
+→ **6/6 항목 메모리 일치. 정정 제안 없음** (직접 측정이 메모리와 동일하므로 정정 불필요).
+
+### 3.1 bkit-relevant 플래그 독립 검증 (2건 → 둘 다 no-op)
+
+| Bullet | 검증 방법 | 결과 |
+|--------|-----------|------|
+| #12 MCP per-server timeout <1000ms | `Read .mcp.json` + `Grep "timeout" .mcp.json` | 두 서버(bkit-pdca, bkit-analysis) `command`/`args`/`env`만, **timeout 필드 0개** → no-op 확정. 현 상태(필드 없음=default fallback)가 v162에서 가장 안전 |
+| #20 CLAUDE_CODE_TMPDIR/SendMessage | `Grep "TMPDIR\|SendMessage\|CLAUDE_CODE_TMPDIR"` 전체 repo | 3건 모두 stale 문서 참조(memory/cc_version_history_v2117_v2119.md, docs/reference/cc-issue-monitoring.md ×2). **hooks/lib/scripts 런타임 코드 참조 0건** → no-op 확정 |
+
+### 3.2 soft-breaking 후보 → bkit 컴포넌트 매핑
+
+| Bullet | bkit 컴포넌트 | 영향 | 근거 |
+|--------|---------------|------|------|
+| #2 `--tools` Grep/Glob native | agents/*.md (tools frontmatter) | Neutral / 잠재 auto-benefit | bkit agent가 tools에 Grep/Glob 명시하지 않음. 동작 개선 방향, breaking 아님 |
+| #6 Windsurf→Devin rename | 없음 | Neutral | bkit는 `/ide`/`/terminal-setup`/`/scroll-speed` 미사용 |
+| #8 WebFetch domain precedence | 없음 (permissions) | Neutral (auto-benefit) | bkit는 `WebFetch(domain:...)` 규칙 미배포 |
+| #9 Windows 권한 + Read deny | lib/permission, scripts/ | Neutral (auto-benefit) | bkit는 Read deny 규칙 미배포, 권한 정확성 자동 수혜 |
+| #12 MCP timeout <1000ms | .mcp.json | Neutral (검증 no-op) | timeout 필드 0개 |
+| #28 startup 메시지 제거 | 없음 | Neutral | bkit는 startup 메시지 파싱 안 함 |
+
+**Hook 스키마 변경: 없음. PreToolUse/PostToolUse: 없음. Agent/Skill frontmatter 스키마: 없음.** → `test/contract/hook-input-schema.test.js`, `hook-output-schema.test.js` 갱신 불필요.
+
+---
+
+## 4. ENH 기회 식별 (Phase 3 Plan Plus + YAGNI)
+
+신규 ENH **0건 (14-cycle 연속)**. ENH-329 미소비.
+
+| 후보 | 출처 | 판정 | 사유 (철학 체크) |
+|------|------|------|------------------|
+| native 검색도구 마이그레이션 | #2 | **DROP** | 현 agent tools 정의는 CC가 이미 자동 처리. 명시적 Grep/Glob 추가는 동작 변화 없이 토큰만 소비. **No Guessing**: 실측 동작 개선 미확인 상태 40개 agent 일괄 수정 근거 부족 |
+| Windows 권한 정확성 활용 | #9 | **DROP** | bkit 부착점(Read deny 규칙) 없음 → 작업 대상 0 |
+| MCP timeout 명시 | #12 | **REJECT** | timeout 추가 시 v162 <1000ms 무시·watchdog 변경에 오히려 노출. 현 상태(필드 없음)가 최선. **Docs=Code**: 불필요 필드 추가 안 함 |
+
+→ 13-cycle 연속 무변경 = 성숙 아키텍처 신호. 추측성 ENH 거부가 No Guessing 철학에 부합.
+
+---
+
+## 5. 차별화 6/6 streak 갱신
+
+v162 bullet 중 #56293/#57317/#58904 root cause 해결 항목 **없음** → 카운터 +1:
+
+| Issue | ENH | 이전 | 갱신 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 (P0) | 18 | **19** | CLOSED-not-planned, bkit Diff #3 sequential dispatch 유일 mitigation 유지 |
+| #57317 PostToolUse drop | ENH-303 (P1) | 12 | **13** | v162 PostToolUse/plugin-loader 변경 0건, root cause 미해결 |
+| #58904 heredoc bypass | ENH-310 (P1) | 8 | **9** | OPEN security, v162 config-write 관련 변경 없음 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+---
+
+## 6. R-Series Regression Tracker + Release Drift
+
+| 패턴 | 본 delta 증감 | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | v162 full GitHub release notes 존재 |
+| R-2 true semver skip | +0 | v161→v162 연속, triple-present (npm+GitHub tag+CHANGELOG) |
+| R-3 hotfix chain | +0 | v162 hotfix 연쇄 징후 없음 |
+
+- **release_drift_score**: stable=2.1.152 / latest=2.1.162 → **drift = 10 패치 (CRITICAL band ≥8)**. stable 채널 사용자는 안전하나, latest 대비 +10 격차 — stable 격상 결정 권고. (prior batch stable 2.1.150 → 2.1.152 전진)
+
+---
+
+## 7. OTEL Monitor
+
+MON-CC-NEW-BG-OTEL-DROP (#64436): v162 OTEL 관련 bullet **0건**. 모니터 **STAYS ACTIVE**, `expectedFix: null` 그대로. (v161 init-race fix는 shutdown-flush drop 모니터와 반대 lifecycle — phase 단위 대조 원칙 유지)
+
+---
+
+## 8. 최종 평결 및 권장 조치
+
+| 항목 | 값 |
+|------|----|
+| Critical regressions | **0건** |
+| Breaking / Breaking-equivalent | **0건 / 0건** (soft-breaking 6건 전부 실측 no-op) |
+| bkit 소스 변경 필요 | **N** (14-cycle 연속 무수정) |
+| Consecutive compatible | **113 → 114** (v2.1.34~v2.1.162) |
+| 신규 ENH | **0건** (14-cycle 연속, ENH-329 미소비) |
+| 권장 CC 액션 | **v2.1.162 즉시 격상 (ADOPT)** — auto-benefit 4건(보안 2 + robustness 2), Breaking 0. stable(2.1.152) drift +10 advisory |
+
+### 8.1 메모리 갱신 사항 (반영 완료)
+- New-ENH-zero streak: 13 → **14**
+- Consecutive compatible: 113 → **114**
+- Differentiation: #56293=**19**, #57317=**13**, #58904=**9**
+- Architecture baseline: 6/6 재측정 일치, 정정 없음
+- 마지막 ENH 번호: ENH-328 유지 (ENH-329 미소비)
+- 다음 baseline: **v2.1.162** (다음 분석 v2.1.163부터)
+
+---
+
+## 9. Quality Checklist
+
+- [x] 모든 CC 변경(28 bullets) 수집 및 분류
+- [x] 각 변경 impact 분류 (HIGH/MEDIUM/LOW)
+- [x] Phase 1.5 raw gate 통과 (researcher 27 → raw 28, errata 회피)
+- [x] raw CHANGELOG + GitHub release tag 이중 fetch
+- [x] bullet count cross-verify (양 소스 28 identical)
+- [x] ≥3 spot-check (#8/#12/#20) verbatim 확인
+- [x] 아키텍처 6/6 직접 재측정 (정정 없음)
+- [x] ENH 우선순위 (0건, YAGNI DROP/REJECT 사유 기록)
+- [x] 철학 준수 검증 (No Guessing / Docs=Code)
+- [x] 파일 영향 매트릭스 + 테스트 영향(0건)
+- [x] 한국어 보고서 + memory 파일
+- [x] Executive Summary 4-perspective 가치 테이블

--- a/docs/04-report/features/cc-v2162-v2168-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2162-v2168-impact-analysis.report.md
@@ -1,0 +1,263 @@
+# CC v2.1.162 → v2.1.168 영향 분석 및 bkit 대응 보고서 (ADR 0003 열아홉 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 19번째 정식 적용, 신규 ENH(implement) 0건 **15-cycle 연속**, **119 consecutive compatible milestone**, **6-version multi-delta (46 bullets, v164 true skip)**, Breaking 0건 / Breaking-equivalent 0건, 차별화 6/6 streak 갱신 (#56293→20 / #57317→14 / #58904→10), **OTEL 모니터 STAYS ACTIVE (v163~168 OTEL bullet 0건)**, Phase 1.5 게이트 **over-count trap 회피** (researcher 47 → raw 46), R-2 skip 1건(v164))
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (bkit.config.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst
+> **Date**: 2026-06-08
+> **PDCA Cycle**: cc-version-analysis (v2.1.162 → v2.1.168, **6-version multi-delta** — 직전 v2.1.162 분석 이후 신규 v163/165/166/167/168, v164 결번)
+> **CC Range**: v2.1.162 (baseline) → **v2.1.168** (npm latest, installed=2.1.168, 게시자 wolffiex)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking 0건 / Breaking-equivalent 0건 / 신규 ENH(implement) 0건 15-cycle 연속 / 차별화 6/6 streak 갱신 / 119 consecutive milestone / OTEL 모니터 #64436 STAYS ACTIVE / 권장 CC v2.1.168 즉시 격상 / ⚠️ 유지보수 발견 1건(MF-1) — cc-version-checker RECOMMENDED_VERSION ~50릴리스 stale, 팀 결정 필요**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (v163/v166 Breaking 섹션 부재, flat list) |
+| **Breaking-equivalent** | **0건** — soft-breaking 후보(v163 #1 managed version-gate / #16 hook `if:` 매칭 / #17 deny `$HOME` / v166 #2 deny glob / #3 SendMessage authority / #16 MCP `${VAR}` predicate)는 **bkit 부착점 0건 실측 확인**되어 무영향. 핵심 근거: **bkit는 `settings.json`을 전혀 배포하지 않음** + **dispatcher는 SendMessage가 아닌 Task spawn 사용** |
+| **bkit-friendly (auto-benefit)** | **3건** — v163 #4 Stop/SubagentStop `additionalContext`가 hook-error로 분류되지 않고 턴 지속(**bkit가 이미 사용 중** → native 강화) / v163 #16 hook `if:` subshell·backtick 매칭(Diff#6 자동 강화) / v163 #9 `$TMPDIR` 전역 override 회귀(2.1.154) 복구(robustness) |
+| **out-of-scope (무영향)** | **다수** — JetBrains 렌더링, Kitty 키보드, voice mode, `claude agents` UI, PowerShell/Windows, bg-pty-host 등 ~35 bullets |
+| **OTEL 모니터 #64436 처리** | **STAYS ACTIVE** — v163~v168에 OTEL/telemetry/metrics shutdown-flush 관련 bullet **0건**. `expectedFix: null` / `resolvedAt: null` 유지 |
+| **신규 ENH(implement) 후보** | **0건 (15-cycle 연속)** — fallbackModel 가이드/version-pin 문서 후보 2건 모두 **Deferred(doc-only)**, ENH 번호 미소비 |
+| 마지막 ENH 번호 | ENH-328 (변동 없음, ENH-329 미소비 유지, ENH-317 CANCELLED 유지) |
+| **차별화 6/6 streak 갱신** | **#56293 19→20 (ENH-292 P0) / #57317 13→14 (ENH-303 P1) / #58904 9→10 (ENH-310 P1)** — 46 bullets 중 3대 이슈 root cause 해결 0건, streak 연장 |
+| **메모리 정정** | 없음 — bkit baseline 6/6 항목 직접 재측정 일치 (v2.1.22 / agents 40 (model 40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2) |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (현재 main GA 안정, 119 consecutive milestone 입증) |
+| **유지보수 발견 (MF-1)** | ⚠️ `lib/infra/cc-version-checker.js:40` `RECOMMENDED_VERSION = '2.1.118'` — 현 latest/installed(2.1.168) 대비 ~50릴리스 stale. **분석 전용 스킬이므로 본 cycle에서 수정하지 않고 flag만** — 지원 floor 정책은 팀 결정 필요 (No Guessing) |
+| **연속 호환 릴리스** | **119 milestone** (v2.1.34 → v2.1.168, 114 → 119, +5 게시 — v163/165/166/167/168, R-2 skip v134/135/151/155/164 제외) |
+| ADR 0003 적용 | **YES (19번째 정식 적용)** |
+| **권장 CC 버전** | **v2.1.168 즉시 격상 권고** (auto-benefit 3건, Breaking 0, clean delta). **보수적 권장 stable v2.1.153 drift +15 CRITICAL band** → stable 격상 결정 권고 |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.162 → v2.1.168 영향 분석 (ADR 0003 19번째)        │
+│  ★ 6-version multi-delta (46 bullets, v164 true skip)    │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 46 bullets (raw-verified)              │
+│      v163: 22 / v166: 21 / v165·167·168: 1 each (3)     │
+│      v164: 결번 (R-2 true skip, 3-source 확인)          │
+│  🔍 Phase 1.5 게이트: researcher 47 → raw 46            │
+│      (over-count trap 회피 — v166 22→21,               │
+│       raw CHANGELOG = GitHub tag byte-identical)         │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking: 0건 / Breaking-equivalent: 0건             │
+│      • bkit는 settings.json 미배포 → deny/managed       │
+│        설정 변경(v163#17, v166#2/#16) 전부 Neutral      │
+│      • dispatcher = Task spawn (≠ SendMessage)          │
+│        → v166#3 cross-session authority 무관             │
+│  🟢 auto-benefit 3건                                     │
+│      • v163#4 Stop/SubagentStop additionalContext       │
+│        (bkit 이미 사용 → native 강화, Diff#1/#5)        │
+│      • v163#16 hook if: subshell·backtick 매칭(Diff#6)  │
+│      • v163#9 $TMPDIR 전역 override 회귀 복구(robust)   │
+│  🆕 신규 ENH(implement): 0건 (15-cycle 연속)            │
+│  ⚠️ 유지보수 발견 MF-1: RECOMMENDED_VERSION 2.1.118     │
+│      ~50릴리스 stale (flag only, 팀 결정 필요)          │
+│  📈 차별화 6/6 streak: #56293→20 #57317→14 #58904→10   │
+│  ✅ 연속 호환: 119 milestone (v2.1.34~v2.1.168)         │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 4-Perspective 가치 평가
+
+| 관점 | 평가 | 근거 |
+|------|------|------|
+| **사용자(User)** | ⬆ 개선 | `claude -p` 무한 hang fix(v163 #7), org-managed 권한 startup race fix(v163 #11), bg-task 손실 fix(v163 #12), 모델 overload 시 fallbackModel 복원력(v166 #1), image-processing 에러+토큰낭비 fix(v166 #8) |
+| **개발자(Dev/bkit)** | ⟷ 무영향 | bkit 소스 변경 0건, hook/agent/skill 스키마 변경 없음, 15-cycle 연속 무수정. 단 내부 유지보수 발견 MF-1 별도 |
+| **보안(Security)** | ⬆ 개선 | v166 #3 SendMessage relayed-permission authority 박탈(cross-session 권한 우회 클래스 하드닝), v163 #17 deny `$HOME` 우회 fix, v166 #2 deny-rule glob 문법 강화, v166 #15 invalid managed-entry가 나머지 정책 무력화하던 버그 fix → CC 권한 계층 전반 자동 강화 (bkit Defense layer 하부) |
+| **운영(Ops)** | ⬆ 개선 | v163 #9 `$TMPDIR` bazel/EDR 회귀 복구, v163 #19 bg-session 백그라운드 업데이트, v166 #5 fallback 모델 1회 재시도, v166 #13 orphaned bg-pty-host 100% CPU fix → CI/원격/EDR 환경 안정성 |
+
+---
+
+## 2. CC v2.1.163~v2.1.168 변경사항 (46 bullets, raw-verified)
+
+### 2.1 Phase 1.5 Raw Verification Gate 결과 — over-count trap 회피
+
+| Field | Agent 보고 | Raw 검증 | Source URL | Verdict |
+|-------|:---:|:---:|------|:---:|
+| v163 | 22 | **22** | raw CHANGELOG.md | match |
+| v165 | 1 | 1 | raw CHANGELOG (placeholder) | match |
+| v166 | 22 | **21** | raw CHANGELOG = GitHub release tag (byte-identical) | **errata (raw wins, −1)** |
+| v167 | 1 | 1 | raw CHANGELOG (placeholder) | match |
+| v168 | 1 | 1 | raw CHANGELOG (placeholder) | match |
+| v164 | skip | **skip (헤더 부재)** | npm 404 + GitHub 404 + CHANGELOG 헤더 부재 (3-source) | match |
+| **Total bullets** | **47** | **46** | sum | **errata (raw wins, −1)** |
+
+- **over-count trap 회피 (핵심 학습)**: cc-version-researcher가 v166을 22로 보고(자가 caveat에서 "model-parsed boundary, not byte-exact" 명시) → 메인 세션 raw CHANGELOG.md + GitHub release tag 이중 fetch 결과 **둘 다 21 (byte-identical)** → raw 채택 **21**. 직전 4개 cycle(v2.1.16/145/161/162)이 모두 **under-count** 패턴이었던 반면, 본 cycle은 **첫 over-count 패턴** → 게이트가 양방향 오차를 모두 포착함을 입증.
+- **구조**: v163/v166 CHANGELOG는 sub-heading 없는 **flat list**. Added/Fixed/Improved 분류는 선행 동사 기반이며 소스 명시값 아님.
+- **v164 true skip**: npm(404) + GitHub release(404) + CHANGELOG(헤더 부재) 3-source 교차 확인. R-2 패턴.
+- **spot-check 3건 verbatim 일치**: v166 #2(deny glob `"*"`) / v166 #3(SendMessage authority) / v163 #17(`Read(~/Desktop/**)` `$HOME` deny) — raw 양 소스 일치.
+
+### 2.2 버전별 분류 요약
+
+| 버전 | bullets | 핵심 항목 | 게시자 |
+|------|:---:|------|------|
+| v2.1.163 | 22 | managed version-gate, `/plugin list`, Stop/SubagentStop `additionalContext`, Skills `\$` escape, MCP `CLAUDE_CODE_SESSION_ID` on resume, `$TMPDIR` 회귀 복구, hook `if:` subshell 매칭, deny `$HOME` fix | wolffiex |
+| v2.1.164 | — | **결번 (R-2 true skip)** | — |
+| v2.1.165 | 1 | "Bug fixes and reliability improvements" (placeholder) | wolffiex |
+| v2.1.166 | 21 | `fallbackModel` setting, deny-rule glob, SendMessage authority 하드닝, thinking-disable 의미, managed `${VAR}` predicate fix, JetBrains/Kitty/PowerShell fixes | wolffiex |
+| v2.1.167 | 1 | "Bug fixes and reliability improvements" (placeholder) | wolffiex |
+| v2.1.168 | 1 | "Bug fixes and reliability improvements" (placeholder) | wolffiex |
+
+---
+
+## 3. bkit 영향 분석
+
+### 3.0 아키텍처 베이스라인 직접 재측정 (Numeric Correction Protocol)
+
+| 항목 | 측정값 | 측정 명령 | 이전 메모리 | 판정 |
+|------|:---:|------|:---:|:---:|
+| agents | 40 | `ls agents/*.md \| wc -l` | 40 | 일치 |
+| model: 커버리지 | 40/40 | `grep -l "^model:" agents/*.md \| wc -l` | 40/40 | 일치 |
+| skills | 44 | `ls skills/*/SKILL.md \| wc -l` | 44 | 일치 |
+| lib modules | 190 | `grep -rl "module.exports" lib/ \| wc -l` | 190 | 일치 |
+| lib subdirs | 22 | `ls -d lib/*/ \| wc -l` | 22 | 일치 |
+| MCP servers | 2 | `ls servers/*/index.js \| wc -l` | 2 | 일치 |
+| bkit version | 2.1.22 | `grep version bkit.config.json` | 2.1.22 | 일치 |
+
+→ **6/6 항목 메모리 일치. 정정 제안 없음.** (참고: SessionStart preflight 표기 "34 agents / 174 lib"는 **stale 표기**이며, 실측·직전 메모리 모두 40/190으로 일치. preflight 수치는 채택하지 않음.)
+
+### 3.1 bkit-relevant 플래그 독립 검증 (메인 세션 spot-check 포함)
+
+| Bullet | 검증 방법 | 결과 |
+|--------|-----------|------|
+| **v163 #4** Stop/SubagentStop `additionalContext` | `grep additionalContext scripts/subagent-stop-handler.js` | **이미 구현 확인** — `scripts/subagent-stop-handler.js:124-131`이 `hookSpecificOutput.additionalContext`(nextActionHint)를 방출 중. v163부터 이 출력이 hook-error로 분류되지 않고 턴을 지속 → **auto-benefit** (Diff#1 Memory Enforcer / Diff#5 continueOnBlock 패턴 native 강화). 메인 세션 직접 재확인 완료 |
+| **v163 #16** hook `if:"Bash(...)"` subshell·backtick 매칭 | `heredoc-detector.js` 검토 + 게이트 의미 분석 | CC predicate 매칭 변경일 뿐, **CC 권한시스템의 heredoc-body 사각지대는 그대로** → Diff#6(#58904) **약화시키지 않음**. `lib/defense/heredoc-detector.js` 수정 불필요 |
+| **v163 #17 / v166 #2** deny rules `$HOME` / glob tool-position | repo 전체 `settings.json` 배포 여부 grep | **bkit는 `settings.json`을 배포하지 않음** → deny rule 변경 부착점 0건. Neutral |
+| **v166 #3** SendMessage relayed-permission authority | dispatcher 구현 검토 | dispatcher는 **Task spawn 사용 (≠ SendMessage)** → cross-session authority 변경 무관. Diff#3 sequential dispatch 영향 0건 |
+| **v163 #5** Skills `\$` escape (digit 앞 literal `$`) | `grep '\$[0-9]'` skills command body | 유일 매치는 prose(`$3/Mtok` 등 가격 표기)이며 **command body 아님** → 무관 |
+| **v163 #6 / v166 #16** MCP `CLAUDE_CODE_SESSION_ID` / `${VAR}` predicate | `Read .mcp.json` | 두 서버(bkit-pdca, bkit-analysis) `command`/`args`/`env`만, predicate·`${VAR}`·timeout 필드 0개 → no-op |
+| **v166 #1** `fallbackModel` setting | agents frontmatter (40/40 `model:`) | per-agent `model:`은 frontmatter 고정값. `fallbackModel`은 CC 세션 레벨 설정 → agent 스키마 무관. Neutral |
+| **v163 #1** `requiredMinimumVersion`/`requiredMaximumVersion` managed settings | bkit 배포 모델 | bkit는 **plugin**이며 managed settings 소유 주체 아님 → 직접 부착점 없음. (단 enterprise 사용자 대상 문서화 후보 — §4 참조) |
+
+### 3.2 soft-breaking 후보 → bkit 컴포넌트 매핑
+
+| Bullet | bkit 컴포넌트 | 영향 | 근거 |
+|--------|---------------|------|------|
+| v163 #1 managed version-gate | 없음 | Neutral | bkit는 managed settings 미소유 |
+| v163 #16 hook `if:` 매칭 | hooks/ (Bash-guard) | Neutral / auto-benefit | CC predicate 정확도 향상, bypass surface 축소 |
+| v163 #17 deny `$HOME` | 없음 (settings 미배포) | Neutral | deny 규칙 미배포 |
+| v166 #2 deny glob | 없음 (settings 미배포) | Neutral | deny 규칙 미배포 |
+| v166 #3 SendMessage authority | sub-agent-dispatcher.js | Neutral | Task spawn 사용, SendMessage 미사용 |
+| v166 #16 MCP `${VAR}` predicate | .mcp.json | Neutral | predicate 필드 0개 |
+
+**Hook 스키마 변경: 없음. PreToolUse/PostToolUse: 없음. Agent/Skill frontmatter 스키마: 없음.** → `test/contract/hook-input-schema.test.js`, `hook-output-schema.test.js` 갱신 불필요.
+
+---
+
+## 4. ENH 기회 식별 (Phase 3 Plan Plus + YAGNI)
+
+신규 ENH(implement) **0건 (15-cycle 연속)**. ENH 번호 미소비(ENH-328 유지, ENH-329 미소비).
+
+### 4.1 Intent Discovery
+- **이 업그레이드의 최대 가치**: v163 #4가 bkit의 기존 `additionalContext` 방출 패턴을 first-class로 격상 — bkit가 이미 쓰던 패턴이 native 지원으로 바뀌어 추가 작업 없이 견고성 상승.
+- **놓치면 안 되는 critical change**: 없음(Breaking 0). 단 **내부적으로** RECOMMENDED_VERSION stale(MF-1)은 사용자에게 잘못된 warn을 띄울 수 있어 별도 추적 필요.
+- **workaround 대체 native 기능**: v163 #4 (additionalContext가 더 이상 hook-error 아님).
+
+### 4.2 후보 평가 (YAGNI)
+
+| 후보 | 출처 | 판정 | 사유 (철학 체크) |
+|------|------|------|------------------|
+| fallbackModel 사용 가이드 문서 | v166 #1 | **Deferred (doc-only, 번호 미소비)** | bkit agent는 per-agent `model:` 고정. fallbackModel은 세션 설정으로 bkit 코드 부착점 없음. 실사용 수요 미확인 → **No Guessing**. 향후 enterprise 가이드에 1-liner로 충분 |
+| version-pin 문서화 (requiredMin/Max) | v163 #1 | **Deferred (doc-only, 번호 미소비)** | bkit는 managed settings 미소유. enterprise 사용자가 CC 버전 floor를 강제하려는 경우 docs/06-guide에 참조 추가 가능하나 현 수요 없음 → **YAGNI** |
+| Stop/SubagentStop additionalContext 활용 | v163 #4 | **DROP** | 이미 구현됨(`subagent-stop-handler.js:124-131`). 추가 작업 불필요 → auto-benefit으로 분류 |
+| native deny-glob/managed 설정 채택 | v166 #2/#16 | **DROP** | bkit settings.json 미배포 정책 → 작업 대상 0 |
+
+→ 15-cycle 연속 무변경 = 성숙 아키텍처 신호. 추측성 ENH 거부가 No Guessing 철학에 부합.
+
+### 4.3 ⚠️ 유지보수 발견 (MF-1) — ENH와 별개
+
+| 항목 | 내용 |
+|------|------|
+| **위치** | `lib/infra/cc-version-checker.js:40` |
+| **현 값** | `const RECOMMENDED_VERSION = '2.1.118';` |
+| **문제** | 현 latest/installed = 2.1.168. 권장값이 ~50릴리스 stale → 2.1.118 미만 사용자에게만 warn이 떠야 하나, 실질 권장 라인(MEMORY: 보수 v2.1.123 / 균형 v2.1.140)과도 불일치 |
+| **본 cycle 조치** | **flag만 (수정 안 함)** — 본 스킬은 분석 전용(HARD-GATE). 또한 임의 bump은 **No Guessing** 위반: 팀이 "지원 floor"(어느 버전을 최소 권장으로 강제할지)를 결정해야 함 |
+| **권고** | 별도 PDCA/유지보수 작업으로 RECOMMENDED_VERSION 정책 갱신 (후보: 마지막 fully-analyzed v2.1.168, 또는 MEMORY 균형선 v2.1.140). `lib/infra/cc-version-checker.js:198~203` 분기 로직은 정상 |
+
+---
+
+## 5. 차별화 6/6 streak 갱신
+
+v163~v168 bullet 중 #56293/#57317/#58904 root cause 해결 항목 **없음** → 카운터 +1:
+
+| Issue | ENH | 이전 | 갱신 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 (P0) | 19 | **20** | CLOSED-not-planned, bkit Diff#3 sequential dispatch 유일 mitigation 유지. v163~168 caching bullet 0건 |
+| #57317 PostToolUse drop | ENH-303 (P1) | 13 | **14** | v163 #4는 Stop/SubagentStop additionalContext일 뿐 PostToolUse drop/ordering 무관. root cause 미해결 |
+| #58904 heredoc bypass | ENH-310 (P1) | 9 | **10** (✦ 10 milestone) | OPEN security. **v163 #16(hook `if:` subshell 매칭)은 predicate 매칭 변경일 뿐 heredoc-body 사각지대 미해결** → Diff#6 약화 없음 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+**핵심 구분 (메모리 반영)**: v163 #16과 #58904는 별개 — #16은 CC가 사용자 정의 hook `if:` 조건을 평가할 때 subshell/backtick 내부 명령까지 매칭하도록 한 fix이고, #58904(Diff#6)는 CC **권한 시스템**이 heredoc body 내 위험 명령을 검사하지 못하는 사각지대. bkit `heredoc-detector.js`는 후자를 보강하므로 v163 #16과 무관하게 유효.
+
+---
+
+## 6. R-Series Regression Tracker + Release Drift
+
+| 패턴 | 본 delta 증감 | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | v165/167/168 placeholder note이나 CHANGELOG+GitHub release 존재 (silent 아님) |
+| R-2 true semver skip | **+1 (v164)** | npm 404 + GitHub 404 + CHANGELOG 헤더 부재 3-source 확정. 누적 skip: v134/135/151/155/**164** |
+| R-3 hotfix chain | +0 | v167/v168 연속 placeholder이나 회귀 연쇄 징후 없음 |
+
+- **release_drift_score (ENH-309)**: stable=2.1.153 / latest=2.1.168 → **drift = 15 패치 (CRITICAL band ≥8)**. stable 채널 사용자는 안전하나 latest 대비 +15 — 역대 최대 격차. stable 격상 결정 권고. (prior batch stable 2.1.152 → 2.1.153 전진)
+
+---
+
+## 7. OTEL Monitor
+
+MON-CC-NEW-BG-OTEL-DROP (#64436): v163~v168에 OTEL/telemetry/metrics shutdown-flush 관련 bullet **0건**. 모니터 **STAYS ACTIVE**, `expectedFix: null` / `resolvedAt: null` 그대로.
+
+---
+
+## 8. 최종 평결 및 권장 조치
+
+| 항목 | 값 |
+|------|----|
+| Critical regressions | **0건** |
+| Breaking / Breaking-equivalent | **0건 / 0건** (soft-breaking 후보 전부 실측 no-op — settings.json 미배포 + Task spawn dispatch) |
+| bkit 소스 변경 필요 | **N** (15-cycle 연속 무수정) — 단 MF-1 별도 유지보수 권고 |
+| Consecutive compatible | **114 → 119** (v2.1.34~v2.1.168, R-2 v164 제외) |
+| 신규 ENH(implement) | **0건** (15-cycle 연속, ENH 번호 미소비) |
+| 권장 CC 액션 | **v2.1.168 즉시 격상 (ADOPT)** — auto-benefit 3건, Breaking 0. stable(2.1.153) drift +15 CRITICAL advisory |
+| ⚠️ 유지보수 권고 | **MF-1**: cc-version-checker RECOMMENDED_VERSION(2.1.118) 갱신 — 별도 작업, 팀이 지원 floor 결정 |
+
+### 8.1 메모리 갱신 사항 (반영 완료)
+- New-ENH(implement)-zero streak: 14 → **15**
+- Consecutive compatible: 114 → **119**
+- Differentiation: #56293=**20**, #57317=**14**, #58904=**10** (✦ 10 milestone)
+- R-2 skip 누적: v134/135/151/155 → **+v164**
+- Architecture baseline: 6/6 재측정 일치, 정정 없음
+- 마지막 ENH 번호: ENH-328 유지 (ENH-329 미소비)
+- 신규 메모리: "no settings.json — hook-based defense" 판정 근거 (향후 deny/allow/managed-settings 변경 = Neutral 자동 판정)
+- 유지보수 추적: **MF-1** RECOMMENDED_VERSION stale
+- 다음 baseline: **v2.1.168** (다음 분석 v2.1.169부터)
+
+---
+
+## 9. Quality Checklist
+
+- [x] 모든 CC 변경(46 bullets, v164 skip 포함) 수집 및 분류
+- [x] 각 변경 impact 분류 (HIGH/MEDIUM/LOW)
+- [x] Phase 1.5 raw gate 통과 (researcher 47 → raw 46, over-count trap 회피)
+- [x] raw CHANGELOG + GitHub release tag 이중 fetch (v166 byte-identical 21)
+- [x] bullet count cross-verify (v163=22 / v166=21 / placeholder 3 / v164 skip)
+- [x] v164 true skip 3-source 확인 (npm+GitHub+CHANGELOG)
+- [x] ≥3 spot-check (v166 #2/#3, v163 #17) verbatim 확인
+- [x] 메인 세션 actionable 클레임 직접 재검증 (RECOMMENDED_VERSION:40, subagent-stop-handler:124-131)
+- [x] 아키텍처 6/6 직접 재측정 (정정 없음)
+- [x] ENH 우선순위 (implement 0건, Deferred/DROP 사유 기록)
+- [x] 철학 준수 검증 (No Guessing / Docs=Code / Automation First)
+- [x] 파일 영향 매트릭스 + 테스트 영향(0건)
+- [x] 한국어 보고서 + memory 파일
+- [x] Executive Summary 4-perspective 가치 테이블
+- [x] 유지보수 발견(MF-1) flag (분석 전용 — 미수정)

--- a/docs/04-report/features/cc-v2168-v2169-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2168-v2169-impact-analysis.report.md
@@ -1,0 +1,257 @@
+# CC v2.1.168 → v2.1.169 영향 분석 및 bkit 대응 보고서 (ADR 0003 스무 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 20번째 정식 적용 ✦, 신규 ENH(implement) 0건 **16-cycle 연속**, **120 consecutive compatible milestone ✦**, **1-version delta (30 bullets, 실질 delta — placeholder 아님)**, Breaking 0건 / Breaking-equivalent 0건, auto-benefit 6건, 차별화 6/6 streak 갱신 (#56293→21 / #57317→15 / #58904→11), **OTEL 모니터 + skill_post plugin-hook-drop 모니터 둘 다 STAYS ACTIVE**, Phase 1.5 게이트 tail-total 산술오류 회피 (수동 열거 30 확정), R-2 skip 0건, MF-1 carry-forward)
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (bkit.config.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst
+> **Date**: 2026-06-09
+> **PDCA Cycle**: cc-version-analysis (v2.1.168 → v2.1.169, **1-version delta** — 직전 v2.1.168 분석 이후 신규 v169)
+> **CC Range**: v2.1.168 (baseline) → **v2.1.169** (npm latest, 2026-06-08 21:57 UTC publish, GitHub author @ashwin-ant / npm wolffiex, installed=2.1.169)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking 0건 / Breaking-equivalent 0건 / 신규 ENH(implement) 0건 16-cycle 연속 / auto-benefit 6건 / 차별화 6/6 streak 갱신 / 120 consecutive milestone / OTEL #64436 + skill_post plugin-hook-drop 모니터 STAYS ACTIVE / 권장 CC v2.1.169 즉시 격상 / MF-1 carry-forward(미해결)**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (v169 flat list 30 bullets, 제거/API 파괴 0건) |
+| **Breaking-equivalent** | **0건** — soft-breaking 후보(#1 `--safe-mode`, #3 `disableBundledSkills`, #5 managed MCP 강제, #14 bg env drop, #26 CLAUDE.md threshold)는 **bkit 부착점 0건 실측 확인** |
+| **bkit-friendly (auto-benefit)** | **6건** — #5 managed MCP allow/deny 강제 누락 fix(governance) / #14 pre-warmed worker가 project `env`(ANTHROPIC_MODEL) 무시하던 버그 fix(Diff#3 dispatch 결정성↑) / #16 plugin `.in_use` PID lock GC(bkit=plugin 수혜) / #17 untrusted OTEL client-cert trust fix(security) / #19 `TaskCreate` 자동복구(bkit TaskCreate 다용) / #23 managed-settings invalid-entry 부분적용(governance) |
+| **out-of-scope (무영향)** | **24 bullets** — UI/렌더링, Windows/WSL, macOS stall, OAuth, statusline, promo 등 |
+| **OTEL 모니터 #64436 처리** | **STAYS ACTIVE** — v169 유일 OTEL bullet은 #17(untrusted client-cert **trust** fix)로 shutdown-flush metric-drop(#64436)과 별개. `expectedFix: null` 유지 |
+| **skill_post plugin-hook-drop 모니터 처리** | **STAYS ACTIVE** — 본 세션 preflight `missing=[skill_post]` 재발. v169 plugin bullet은 #15(MCPB cache)·#16(PID lock GC)뿐, **hook reachability 미해결** |
+| **신규 ENH(implement) 후보** | **0건 (16-cycle 연속)** — #1 safe-mode 문서화 후보는 P3 DEFER(번호 미소비) |
+| 마지막 ENH 번호 | ENH-328 (변동 없음, ENH-329 미소비 유지, ENH-317 CANCELLED 유지) |
+| **차별화 6/6 streak 갱신** | **#56293 20→21 (ENH-292 P0) / #57317 14→15 (ENH-303 P1) / #58904 10→11 (ENH-310 P1)** — 30 bullets 중 3대 이슈 root cause 해결 0건 |
+| **메모리 정정** | 없음 — bkit baseline 6/6 직접 재측정 일치 (v2.1.22 / agents 40 (40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2) |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (120 consecutive milestone 입증) |
+| **유지보수 발견 (MF-1, carry-forward)** | ⚠️ `lib/infra/cc-version-checker.js:40` `RECOMMENDED_VERSION = '2.1.118'` — 현 latest 2.1.169 대비 ~51릴리스 stale. 직전 cycle flag 이후 **미해결 carry-forward**. 분석 전용 스킬이므로 미수정, 팀 결정 필요(No Guessing) |
+| **연속 호환 릴리스** | **120 milestone ✦** (v2.1.34 → v2.1.169, 119 → 120, +1 — R-2 skip v134/135/151/155/164 제외) |
+| ADR 0003 적용 | **YES (20번째 정식 적용 ✦)** |
+| **권장 CC 버전** | **v2.1.169 즉시 격상 권고** (auto-benefit 6건, Breaking 0). **보수적 권장 stable v2.1.153 drift +16 CRITICAL band (역대 최대)** → stable 격상 결정 권고 |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.168 → v2.1.169 영향 분석 (ADR 0003 20번째 ✦)      │
+│  ★ 1-version 실질 delta (30 bullets, placeholder 아님)   │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 30 bullets (raw-verified)              │
+│      Added 3 / Fixed 14 / Improved·Other 13              │
+│  🔍 Phase 1.5 게이트: tail-total 산술오류 회피           │
+│      • researcher 30 / WebFetch 자가총계 38·31 (오산)   │
+│      • raw CHANGELOG = GitHub tag verbatim 리스트 동일   │
+│      • 메인 세션 행 단위 수동 열거 → 30 확정             │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking: 0건 / Breaking-equivalent: 0건             │
+│      • #1 safe-mode: bkit 로드 前 CC레벨 전체 차단       │
+│        → bkit 저항 불가·불필요(의도된 동작), 부착점 0   │
+│      • #3 disableBundledSkills: CC 내장 스킬 한정,       │
+│        bkit 44 skills=plugin-provided → 무관             │
+│  🟢 auto-benefit 6건 (#5/#14/#16/#17/#19/#23)           │
+│  🆕 신규 ENH(implement): 0건 (16-cycle 연속)            │
+│      • #1 safe-mode 문서화 → P3 DEFER(번호 미소비)      │
+│  ⚠️ MF-1 carry-forward: RECOMMENDED_VERSION 2.1.118     │
+│      ~51릴리스 stale (미해결, 팀 결정 필요)             │
+│  📈 차별화: #56293→21 #57317→15 #58904→11               │
+│  ✅ 연속 호환: 120 milestone ✦ (v2.1.34~v2.1.169)       │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 4-Perspective 가치 평가
+
+| 관점 | 평가 | 근거 |
+|------|------|------|
+| **사용자(User)** | ⬆ 개선 | `--safe-mode` 트러블슈팅 스위치(#1), `/cd` cache-safe cwd 이동(#2), stale 권한 prompt 재출현 fix(#11), `claude -p` Windows hang(2.1.161 회귀) fix(#7), CPU 사용 감소(#21) |
+| **개발자(Dev/bkit)** | ⟷ 무영향 | bkit 소스 변경 0건, hook/agent/skill 스키마 변경 없음, 16-cycle 연속 무수정. MF-1만 별도 carry-forward |
+| **보안(Security)** | ⬆ 개선 | #17 untrusted OTEL client-cert trust 강제(cert 유출 벡터 차단), #5 managed MCP allow/deny 강제 누락 fix(reconnect/IDE/first-session 경로), #23 invalid managed-entry가 전체 정책 무력화하던 버그 fix → CC governance 계층 자동 강화 |
+| **운영(Ops)** | ⬆ 개선 | #14 pre-warmed worker env 누락 fix(dispatch 결정성), #16 plugin PID lock GC(자원 누수 방지), #22 Vertex/Foundry idle timeout 복원, #24 bg-session flag 보존 |
+
+---
+
+## 2. CC v2.1.169 변경사항 (30 bullets, raw-verified)
+
+### 2.1 Phase 1.5 Raw Verification Gate 결과 — tail-total 산술오류 회피
+
+| Field | Agent 보고 | Raw 검증 | Source URL | Verdict |
+|-------|:---:|:---:|------|:---:|
+| Added | 3 | 3 | raw CHANGELOG (분류) | match |
+| Fixed | 14 | 14 | raw CHANGELOG (분류) | match |
+| Improved·Other | 13 | 13 | raw CHANGELOG (분류) | match |
+| **Total bullets** | **30** | **30 (수동 열거)** | raw CHANGELOG = GitHub release tag (verbatim 리스트 byte-identical) | **match** |
+
+- **tail-total 산술오류 회피 (핵심 학습)**: raw CHANGELOG WebFetch와 GitHub release tag WebFetch는 **verbatim 리스트가 완전 동일(30개)**이었으나, 두 응답이 자기가 나열한 리스트의 꼬리 "Total"을 각각 **38 / 31로 오산**. 메인 세션이 행 단위로 직접 열거 → **30 확정**. researcher의 30이 정확.
+- **이번 cycle 교훈 (errata learning)**: 직전 cycle들은 model이 bullet을 *누락/병합*하는 **count miscount**였으나, 본 cycle은 **리스트는 정확하나 합산만 틀린 산술오류** 패턴. → "model이 보고한 Total 숫자"가 아니라 **"열거된 verbatim 리스트를 직접 카운트"** 하는 것이 게이트의 정답. 두 소스 verbatim 동일성이 신뢰의 근거.
+- **구조**: v169 CHANGELOG는 sub-heading 없는 **flat list**. Added/Fixed/Improved 분류는 선행 동사 기반.
+- **게시**: GitHub author @ashwin-ant / npm publisher wolffiex (양립). 2026-06-08 21:57 UTC. v169는 **실질 30-bullet 엔트리(placeholder 아님)** — 직전 v168은 placeholder였음.
+- **spot-check 3건 verbatim 일치**: #5(enterprise managed MCP policies) / #14(background agents ignoring project-level env) / #17(untrusted OTEL client-certificate).
+
+### 2.2 카테고리별 분류 요약
+
+| 그룹 | bullets | 핵심 항목 |
+|------|:---:|------|
+| Added (3) | 1~3 | `--safe-mode`/`CLAUDE_CODE_SAFE_MODE`, `/cd` cache-safe cwd 이동, `disableBundledSkills`/`CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` |
+| Fixed (14) | 4~17 | managed MCP 강제 누락, `claude -p` Windows hang(2.1.161 회귀), agents --json id/state/--all, **bg env(ANTHROPIC_MODEL) drop**, MCPB cache, plugin PID lock, **untrusted OTEL client-cert** |
+| Improved·Other (13) | 18~30 | `/workflows` 즉시 오픈, **TaskCreate 자동복구**, Vertex/Foundry idle timeout, **managed-settings 부분적용**, bg flag 보존, **CLAUDE.md threshold context-scaling**, auto-updater |
+
+---
+
+## 3. bkit 영향 분석
+
+### 3.0 아키텍처 베이스라인 직접 재측정 (Numeric Correction Protocol)
+
+| 항목 | 측정값 | 측정 명령 | 이전 메모리 | 판정 |
+|------|:---:|------|:---:|:---:|
+| agents | 40 | `ls agents/*.md \| wc -l` | 40 | 일치 |
+| model: 커버리지 | 40/40 | `grep -l "^model:" agents/*.md` | 40/40 | 일치 |
+| skills | 44 | `ls skills/*/SKILL.md \| wc -l` | 44 | 일치 |
+| lib modules | 190 | `grep -rl "module.exports" lib/` | 190 | 일치 |
+| lib subdirs | 22 | `ls -d lib/*/ \| wc -l` | 22 | 일치 |
+| MCP servers | 2 | `ls servers/*/index.js` | 2 | 일치 |
+| bkit version | 2.1.22 | `grep version bkit.config.json` | 2.1.22 | 일치 |
+
+→ **6/6 항목 메모리 일치. 정정 제안 없음.** (SessionStart preflight "34 agents/174 lib" stale 표기 — 채택하지 않음.)
+
+### 3.1 bkit-relevant 플래그 독립 검증 (메인 세션 + 분석가 + 메인 재검증)
+
+| Bullet | 검증 방법 | 결과 |
+|--------|-----------|------|
+| **#1** `--safe-mode`/`CLAUDE_CODE_SAFE_MODE` | repo grep + 의미 분석 | bkit 코드 참조 0건. safe-mode는 **bkit 로드 이전 CC 레벨**에서 CLAUDE.md+plugins+skills+hooks+MCP 전체를 끔. bkit Memory Enforcer(Diff#1)/Defense L6(Diff#2)는 이 시점 미로드 → **저항 불가·불필요(의도된 트러블슈팅 동작)**. 부착점 0. P3 문서화 후보만 |
+| **#3** `disableBundledSkills`/`CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` | `skills/bkit/SKILL.md` 분류 확인 | "bundled skills"는 **CC 내장 스킬/명령** 한정. bkit 44 skills는 **plugin-provided** → **무관** |
+| **#12** `claude agents --json` id/state/--all | `grep "agents --json"` lib/scripts/hooks | bkit parser **0건** (lib/scripts의 `--json`은 bkit 자체 jq/test JSON). Neutral |
+| **#14** bg env(ANTHROPIC_MODEL) drop fix | sub-agent-dispatcher.js 의존성 검토 | pre-warmed worker가 project `env`를 honor → **Diff#3 sequential dispatch 결정성 향상 (auto-benefit, MEDIUM)** |
+| **#16** plugin `.in_use` PID lock GC | bkit=plugin runtime | stale marker 일일 sweep → bkit 자원 누수 방지 (auto-benefit, LOW) |
+| **#19** `TaskCreate` 자동복구 | `scripts/task-created-handler.js` 검토 | malformed input 자동 복구 + 방어적 read/exit-0 fallback 이미 존재 → 동작변화 위험 없음 (auto-benefit, MEDIUM) |
+| **#26** CLAUDE.md too-long threshold context-scaling | `memory-enforcer.js`, 하드코딩 threshold grep | bkit는 CLAUDE.md **크기 임계값 하드코딩 없음**. `memory-enforcer.js`는 directive *추출* 경계(240/200), context-sizer는 sprint *토큰 예산*(100K) — 둘 다 CLAUDE.md 길이 gate 아님. Neutral |
+| **#5/#23** managed MCP 강제 / 부분적용 | `.mcp.json` + settings 배포 여부 | bkit는 **settings.json 미배포** → 직접 부착점 없음. governance auto-benefit |
+| **#17** untrusted OTEL client-cert | `grep CLIENT_CERTIFICATE lib/` + otel-env-capturer.js | lib/에 client-cert 참조 0건. `otel-env-capturer.js`는 **신뢰된 USER shell env**에서 캡처(project settings 아님) → 노출 없음. Neutral (security auto-benefit) |
+
+### 3.2 soft-breaking 후보 → bkit 컴포넌트 매핑
+
+| Bullet | bkit 컴포넌트 | 영향 | 근거 |
+|--------|---------------|------|------|
+| #1 `--safe-mode` | 없음 (CC pre-load) | Neutral | bkit 로드 전 차단, 의도된 동작 |
+| #3 disableBundledSkills | 없음 | Neutral | CC 내장 스킬 한정 |
+| #5 managed MCP 강제 | .mcp.json (settings 미배포) | Neutral / auto-benefit | settings.json 미배포 |
+| #14 bg env drop | sub-agent-dispatcher.js | auto-benefit | env 전달 정확도↑ |
+| #26 CLAUDE.md threshold | memory-enforcer.js | Neutral | 크기 gate 미하드코딩 |
+
+**Hook 스키마 변경: 없음. PreToolUse/PostToolUse/Stop/SubagentStop 이벤트 변경: 없음. Agent/Skill frontmatter 스키마: 없음.** → `test/contract/hook-input-schema.test.js`, `hook-output-schema.test.js` 갱신 불필요.
+
+---
+
+## 4. ENH 기회 식별 (Phase 3 Plan Plus + YAGNI)
+
+신규 ENH(implement) **0건 (16-cycle 연속)**. ENH 번호 미소비(ENH-328 유지).
+
+### 4.1 Intent Discovery
+- **최대 가치**: #14(bg env drop fix)가 bkit Diff#3 sequential dispatch의 env 전달 결정성을 무수정으로 강화. #19(TaskCreate 자동복구)는 bkit의 TaskCreate 다용 패턴을 더 견고하게.
+- **놓치면 안 되는 critical change**: 없음(Breaking 0). 단 #1 `--safe-mode`는 bkit 사용자가 "bkit이 동작 안 한다"고 오인할 수 있는 새 스위치 → 문서화 가치 존재(P3).
+- **workaround 대체 native 기능**: 없음. bkit은 #5/#17/#23 governance 강화를 자동 수혜할 뿐 자체 workaround 보유 안 함.
+
+### 4.2 후보 평가 (YAGNI)
+
+| 후보 | 출처 | 판정 | 사유 (철학 체크) |
+|------|------|------|------------------|
+| `--safe-mode` 동작 문서화 (bkit 비활성 설명) | #1 | **P3 DEFER (번호 미소비)** | 트러블슈팅용 CC 표준 스위치. bkit이 의도적으로 우회됨은 정상. 현 사용자 혼란 보고 0건 → **YAGNI**. 향후 docs/06-guide FAQ에 1-liner면 충분. **No Guessing**: 실수요 미확인 |
+| `disableBundledSkills` 영향 안내 | #3 | **DROP** | bkit skills=plugin-provided로 무관 → 작업 대상 0 |
+| `agents --json` id/state 파서 추가 | #12 | **DROP** | bkit은 `claude agents --json` 미파싱 → 부착점 없음 |
+| managed MCP/OTEL governance 채택 | #5/#17/#23 | **DROP** | bkit settings.json 미배포 정책 → auto-benefit으로 충분 |
+
+→ 16-cycle 연속 무변경 = 성숙 아키텍처 신호. 추측성 ENH 거부가 No Guessing 철학에 부합.
+
+### 4.3 ⚠️ 유지보수 발견 (MF-1, carry-forward) — ENH와 별개
+
+| 항목 | 내용 |
+|------|------|
+| **위치** | `lib/infra/cc-version-checker.js:40` |
+| **현 값** | `const RECOMMENDED_VERSION = '2.1.118';` (직전 cycle 이후 **변동 없음**) |
+| **문제** | 현 latest 2.1.169 대비 ~51릴리스 stale. MEMORY 권장선(보수 2.1.123 / 균형 2.1.140)과도 불일치 |
+| **본 cycle 조치** | **flag 유지 (미수정)** — 분석 전용 스킬(HARD-GATE) + 임의 bump은 No Guessing 위반 |
+| **권고** | 별도 유지보수 작업으로 정책 갱신. 분기 로직(`:198~203`) 정상. **2-cycle 연속 carry-forward** — 다음 일반 PDCA에서 우선 처리 권고 |
+
+---
+
+## 5. 차별화 6/6 streak 갱신
+
+v169 bullet 중 #56293/#57317/#58904 root cause 해결 항목 **없음** → 카운터 +1:
+
+| Issue | ENH | 이전 | 갱신 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 (P0) | 20 | **21** | v169 #2 `/cd`는 cache **보존** 신기능, #56293 invalidation 미해결. bkit Diff#3 유일 mitigation 유지 |
+| #57317 PostToolUse drop | ENH-303 (P1) | 14 | **15** | v169 PostToolUse 변경 0건. 추가로 **skill_post plugin-hook-drop reachability 미해결**(preflight 재발) |
+| #58904 heredoc bypass | ENH-310 (P1) | 10 | **11** | v169 bash-parsing/heredoc 변경 0건. bkit Diff#6 독립 면역 유지 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+---
+
+## 6. R-Series Regression Tracker + Release Drift
+
+| 패턴 | 본 delta 증감 | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | v169 full CHANGELOG + GitHub release 존재 |
+| R-2 true semver skip | +0 | v168→v169 연속, triple-present |
+| R-3 hotfix chain | +0 | 회귀 연쇄 징후 없음 (단 #7은 2.1.161 회귀 fix — 단발) |
+
+- **release_drift_score (ENH-309)**: stable=2.1.153 / latest=2.1.169 → **drift = 16 패치 (CRITICAL band ≥8, 역대 최대 갱신)**. stable 채널 사용자 안전하나 latest 대비 +16 — stable 격상 결정 권고. (prior batch stable 2.1.153 정체)
+
+---
+
+## 7. Monitor 상태
+
+| Monitor | Issue | v169 처리 | 판정 |
+|---------|-------|-----------|------|
+| MON-CC-NEW-BG-OTEL-DROP | #64436 | v169 유일 OTEL bullet #17은 client-cert **trust** fix(shutdown-flush metric-drop과 별개) | **STAYS ACTIVE** (expectedFix: null) |
+| MON-CC-NEW-PLUGIN-HOOK-DROP | #57317 (skill_post) | 본 세션 preflight `missing=[skill_post]` 재발. v169 plugin bullet #15/#16은 cache/PID-GC뿐 hook reachability 미터치 | **STAYS ACTIVE** |
+
+---
+
+## 8. 최종 평결 및 권장 조치
+
+| 항목 | 값 |
+|------|----|
+| Critical regressions | **0건** |
+| Breaking / Breaking-equivalent | **0건 / 0건** (soft-breaking 후보 전부 실측 no-op) |
+| bkit 소스 변경 필요 | **N** (16-cycle 연속 무수정) — MF-1 별도 유지보수 권고(2-cycle carry-forward) |
+| Consecutive compatible | **119 → 120 ✦** (v2.1.34~v2.1.169) |
+| 신규 ENH(implement) | **0건** (16-cycle 연속, ENH 번호 미소비) |
+| 권장 CC 액션 | **v2.1.169 즉시 격상 (ADOPT)** — auto-benefit 6건, Breaking 0. stable(2.1.153) drift +16 CRITICAL advisory |
+| ⚠️ 유지보수 권고 | **MF-1 (carry-forward)**: RECOMMENDED_VERSION 갱신 — 별도 작업, 팀이 지원 floor 결정 |
+
+### 8.1 메모리 갱신 사항 (반영 완료)
+- New-ENH(implement)-zero streak: 15 → **16**
+- Consecutive compatible: 119 → **120 ✦**
+- Differentiation: #56293=**21**, #57317=**15**, #58904=**11**
+- R-2 skip 누적: 변동 없음 (v134/135/151/155/164)
+- Architecture baseline: 6/6 재측정 일치, 정정 없음
+- 마지막 ENH 번호: ENH-328 유지 (ENH-329 미소비)
+- Monitor: OTEL #64436 + skill_post plugin-hook-drop 둘 다 STAYS ACTIVE
+- MF-1: RECOMMENDED_VERSION stale **2-cycle carry-forward**
+- 다음 baseline: **v2.1.169** (다음 분석 v2.1.170부터)
+
+---
+
+## 9. Quality Checklist
+
+- [x] 모든 CC 변경(30 bullets) 수집 및 분류
+- [x] 각 변경 impact 분류 (HIGH/MEDIUM/LOW)
+- [x] Phase 1.5 raw gate 통과 (tail-total 산술오류 회피, 수동 열거 30 확정)
+- [x] raw CHANGELOG + GitHub release tag 이중 fetch (verbatim 리스트 byte-identical)
+- [x] bullet count cross-verify (Added 3 / Fixed 14 / Improved 13 = 30)
+- [x] ≥3 spot-check (#5/#14/#17) verbatim 확인
+- [x] 분석가 load-bearing 클레임 직접 재검증 (otel-env-capturer.js, memory-enforcer.js, RECOMMENDED_VERSION:40, agents --json 부재)
+- [x] 아키텍처 6/6 직접 재측정 (정정 없음)
+- [x] ENH 우선순위 (implement 0건, P3 DEFER/DROP 사유 기록)
+- [x] 철학 준수 검증 (No Guessing / Docs=Code / Automation First)
+- [x] 파일 영향 매트릭스 + 테스트 영향(0건)
+- [x] 한국어 보고서 + memory 파일
+- [x] Executive Summary 4-perspective 가치 테이블
+- [x] safe-mode/disableBundledSkills scope 명시 판정
+- [x] Monitor 2건(OTEL + skill_post) 상태 명시

--- a/docs/04-report/features/cc-v2169-v2179-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2169-v2179-impact-analysis.report.md
@@ -1,0 +1,273 @@
+# CC v2.1.169 → v2.1.179 영향 분석 및 bkit 대응 보고서 (ADR 0003 스물한 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 21번째 정식 적용 ✦, 신규 ENH(implement) 0건 **17-cycle 연속**, **128 consecutive compatible milestone ✦**, **10-version delta (102 bullets, raw gh-API authoritative)**, Breaking 0건 / Breaking-equivalent 0건, auto-benefit 4건(헤드라인 hook `if` 수정 포함), 차별화 6/6 streak 갱신 (#56293→22 / #57317→16 / #58904→12), **monitor 4건 전부 유지(BG-OTEL-DROP/PLUGIN-HOOK-DROP/CHOICE-LOOP ACTIVE, STOP-SCHEMA-STRICT RESOLVED)**, Phase 1.5 게이트 model-WebFetch under/over-count 회피 (gh-API base64 디코딩 102 확정), R-2 skip +2건(v171/v177), MF-1 3-cycle carry-forward)
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (plugin.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst
+> **Date**: 2026-06-17
+> **PDCA Cycle**: cc-version-analysis (v2.1.169 → v2.1.179, **10-version delta**)
+> **CC Range**: v2.1.169 (baseline) → **v2.1.179** (npm latest=installed, dist-tags stable=2.1.169 / latest=2.1.179 / next=2.1.179)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking 0건 / Breaking-equivalent 0건 / 신규 ENH(implement) 0건 17-cycle 연속 / auto-benefit 4건 / 헤드라인 v2.1.176 hook `if` 매칭 수정 = auto-benefit MEDIUM / 차별화 6/6 streak 갱신 / 128 consecutive milestone / monitor 4건 전부 유지 / 권장 CC v2.1.179 즉시 격상 / MF-1 3-cycle carry-forward(미해결)**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (102 bullets, 8 present 버전 전체 Added/Fixed/Improved/Changed — 제거/API 파괴 0건) |
+| **Breaking-equivalent** | **0건** — 동작 변경 후보(v178 `Tool(param:value)` 권한 문법, v178 nested `.claude/` precedence, v178 workflow 키워드 트리거 변경)는 **bkit 부착점 0건 실측 확인** |
+| **bkit-friendly (auto-benefit)** | **4건** — **[헤드라인] v2.1.176 hook `if` Read/Edit/Write 경로 매칭 수정(MEDIUM)** / v2.1.179 plugin 로딩 성능 개선(remote, LOW) / v2.1.178 subagent transcript·메시지·backgrounding 수정(DX, LOW) / v2.1.178 auto-mode subagent classifier 사전평가(security governance, LOW) |
+| **Neutral (무영향)** | 대부분 — model picker/Fable 5/Bedrock/Remote Control/background-session/Windows·WSL/VSCode/터미널 UI fix 및 managed-settings(v175 `enforceAvailableModels`, v176 `footerLinksRegexes`)는 bkit settings.json 미배포로 부착점 0 |
+| **헤드라인 (v2.1.176)** | **auto-benefit MEDIUM** — bkit는 `if:` 게이트 훅을 **실제 2건 사용**(`hooks.json:30` `Write(skills/**/SKILL.md)`, `hooks.json:275` `Write|Edit(docs/**/*.md)`). 수정된 문법을 이미 사용 중이고 핸들러가 경로를 **자체 가드** → silent-gap 신뢰성 위험 제거의 순수 이득, breakage·조치 불필요 |
+| **신규 ENH(implement) 후보** | **0건 (17-cycle 연속)** — 모든 후보 YAGNI 탈락(DROP/P3) |
+| 마지막 ENH 번호 | ENH-328 (CC-cycle 기준 변동 없음) / 전역 카운터는 내부 v2.1.22 하드닝으로 ENH-366 소비 → **ENH-367 예약(미소비)** |
+| **차별화 6/6 streak 갱신** | **#56293 21→22 (ENH-292 P0) / #57317 15→16 (ENH-303 P1) / #58904 11→12 (ENH-310 P1)** — 102 bullets 중 3대 이슈 root cause 직접 해결 0건 |
+| **메모리 정정** | 없음 — bkit baseline 재측정 일치 (v2.1.22 / agents 40 / skills 44 / lib 190 modules 22 subdirs) |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (128 consecutive milestone 입증) |
+| **유지보수 발견 (MF-1, carry-forward)** | ⚠️ `lib/infra/cc-version-checker.js:40` `RECOMMENDED_VERSION = '2.1.118'` — 현 latest 2.1.179 대비 ~61릴리스 stale. **3-cycle 연속 미해결 carry-forward**. 분석 전용 스킬이므로 미수정, 팀 결정 필요(No Guessing) |
+| **연속 호환 릴리스** | **128 milestone ✦** (v2.1.34 → v2.1.179, 120 → 128, +8 present — R-2 skip v134/135/151/155/164/**171/177** 제외) |
+| ADR 0003 적용 | **YES (21번째 정식 적용 ✦)** |
+| **권장 CC 버전** | **v2.1.179 즉시 격상 권고** (auto-benefit 4건, Breaking 0). **stable 2.1.169 drift +10 CRITICAL band** (직전 +16에서 개선 — stable이 2.1.153→2.1.169로 따라잡음) |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.169 → v2.1.179 영향 분석 (ADR 0003 21번째 ✦)      │
+│  ★ 10-version delta (102 bullets, gh-API authoritative)  │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 102 bullets (8 present 버전)           │
+│      v170(2) v172(30) v173(2) v174(13) v175(1)          │
+│      v176(22) v178(23) v179(9)                           │
+│      R-2 skip: v171, v177 (changelog floor 132 위 = 진성)│
+│  🔍 Phase 1.5 게이트: model-WebFetch under/over-count    │
+│      • 모델 WebFetch: 179=11 178=16 176=13 174=11 172=27 │
+│      • gh-API base64 디코딩(ground truth): 179=9 178=23  │
+│        176=22 174=13 172=30 → Total 102 확정             │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking: 0건 / Breaking-equivalent: 0건             │
+│  🟢 auto-benefit 4건                                     │
+│      • [헤드라인] v176 hook `if` 매칭 수정 (MEDIUM)      │
+│        bkit 2건 if-gated 훅 신뢰성↑, 조치 불필요         │
+│      • v179 plugin 로딩 성능(remote) / v178 subagent DX  │
+│      • v178 auto-mode classifier 사전평가(security)      │
+│  🆕 신규 ENH(implement): 0건 (17-cycle 연속)            │
+│      • ENH-367 예약(미소비)                              │
+│  ⚠️ MF-1 carry-forward: RECOMMENDED_VERSION 2.1.118     │
+│      ~61릴리스 stale (3-cycle 미해결, 팀 결정 필요)     │
+│  📈 차별화: #56293→22 #57317→16 #58904→12               │
+│  ✅ 연속 호환: 128 milestone ✦ (v2.1.34~v2.1.179)       │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 4-Perspective 가치 평가
+
+| 관점 | 평가 | 근거 |
+|------|------|------|
+| **사용자(User)** | ⬆ 개선 | Fable 5 도입(#v170), mid-stream 연결 끊김 시 부분응답 보존(v179), `/model` 피커 model family 표시 수정(v174), subagent transcript 라이브 진행 표시(v178), WSL2 마우스휠 스크롤 수정(v179) |
+| **개발자(Dev/bkit)** | ⟷ 무영향 (소폭 ⬆) | bkit 소스 변경 0건, hook/agent/skill 스키마 변경 없음, 17-cycle 연속 무수정. **단 v176 hook `if` 매칭 수정으로 bkit 2건 if-gated 훅의 silent-gap 위험 제거(auto-benefit)**. MF-1만 별도 carry-forward |
+| **보안(Security)** | ⬆ 개선 | v178 auto-mode subagent spawn이 launch 前 classifier 평가(차단 우회 갭 차단), v172 `availableModels`가 subagent model override에도 적용, v178 MCP server-level spec이 subagent `disallowedTools`에서 무시되던 버그 fix → CC governance 자동 강화 |
+| **운영(Ops)** | ⬆ 개선 | v179 remote plugin 로딩 성능, v172 long-conversation 성능 + idle CPU 감소, v178 compaction `--fallback-model` honor, background-session 안정성 다수 fix |
+
+---
+
+## 2. CC v2.1.170~v2.1.179 변경사항 (102 bullets, raw gh-API authoritative)
+
+### 2.1 Phase 1.5 Raw Verification Gate 결과 — model-WebFetch under/over-count 회피
+
+| 버전 | model-WebFetch | gh-API raw (authoritative) | Source | Verdict |
+|------|:---:|:---:|------|:---:|
+| 2.1.179 | 11 | **9** | gh-API base64 디코딩 | errata (모델 과다) |
+| 2.1.178 | 16 | **23** | gh-API base64 디코딩 | errata (모델 과소) |
+| 2.1.176 | 13 | **22** | gh-API base64 디코딩 | errata (모델 과소) |
+| 2.1.175 | 1 | 1 | gh-API base64 디코딩 | match |
+| 2.1.174 | 11 | **13** | gh-API base64 디코딩 | errata (모델 과소) |
+| 2.1.173 | 2 | 2 | gh-API base64 디코딩 | match |
+| 2.1.172 | 27 | **30** | gh-API base64 디코딩 | errata (모델 과소) |
+| 2.1.170 | 2 | 2 | gh-API base64 디코딩 | match |
+| **Total bullets** | (불일치) | **102 (행 단위 직접 열거)** | gh-API `contents/CHANGELOG.md \| base64 -d` | **확정** |
+
+- **핵심 학습 (errata learning)**: 1차 model-processed WebFetch는 긴 fix 리스트를 truncate해 대부분 **과소카운트**(178: 16 vs 23, 176: 13 vs 22, 172: 27 vs 30), v179는 역으로 **과다카운트**(11 vs 9). → 게이트 정답은 model 응답이 아니라 **`gh api .../CHANGELOG.md --jq .content | base64 -d`로 디코딩한 raw 파일을 행 단위 직접 열거**하는 것. 본 cycle은 gh-API 디코딩 소스를 ground truth로 채택.
+- **spot-check 3건 verbatim 일치**: v176 `"Fixed hook if conditions for Read/Edit/Write tool paths..."` / v172 `"Sub-agents can now spawn their own sub-agents (up to 5 levels deep)"` / v178 `"Added Tool(param:value) syntax for permission rules..."`.
+- **CHANGELOG floor 구조 발견 (cc-version-researcher)**: rolling `CHANGELOG.md@main`의 하한이 **v2.1.132**. v2.1.69~v2.1.131은 prune(존재했으나 changelog에서 제거)이며 R-2 skip과 구별됨. **본 cycle 범위(v170~v179)는 floor 위라 전부 retained → R-2 판정 신뢰 가능**.
+
+### 2.2 버전별 bullet 인벤토리 + R-2 skip
+
+| 버전 | present | bullets | 핵심 |
+|------|:---:|:---:|------|
+| 2.1.179 | ✓ | 9 | mid-stream 연결끊김 부분응답 보존, WSL2 스크롤, sandbox glob 비대화 fix, **plugin 로딩 성능(remote)** |
+| 2.1.178 | ✓ | 23 | **`Tool(param:value)` 권한 문법**, nested `.claude/skills` 로딩, nested `.claude/` precedence, **auto-mode subagent classifier 사전평가**, subagent transcript/메시지/backgrounding 수정, **MCP server-level spec subagent `disallowedTools` 무시 fix** |
+| **2.1.177** | ✗ | — | **R-2 true skip** (floor 위 retained 범위 내 부재 = 진성 semver skip) |
+| 2.1.176 | ✓ | 22 | **hook `if` Read/Edit/Write 경로 매칭 fix**, `footerLinksRegexes` 설정, `availableModels` enforcement, session title 언어화 |
+| 2.1.175 | ✓ | 1 | `enforceAvailableModels` managed setting |
+| 2.1.174 | ✓ | 13 | `wheelScrollAccelerationEnabled`, `/model` 피커 family/label fix, background-session ANTHROPIC_* env 격리 fix |
+| 2.1.173 | ✓ | 2 | Fable 5 `[1m]` suffix 정규화, Windows sandbox 경고 fix |
+| 2.1.172 | ✓ | 30 | **Sub-agents 5단계 중첩**, `model` attr OTEL `lines_of_code.count`, `availableModels` subagent override 적용 fix, `WebFetch(domain:*.x)` 와일드카드 fix, long-conversation 성능 |
+| **2.1.171** | ✗ | — | **R-2 true skip** (floor 위 retained 범위 내 부재 = 진성 semver skip) |
+| 2.1.170 | ✓ | 2 | **Claude Fable 5 도입**, VS Code 터미널 transcript 미저장 fix |
+
+→ present 8버전, R-2 skip 2건(v171/v177). **Breaking 0 / Breaking-equivalent 0.**
+
+---
+
+## 3. bkit 영향 분석
+
+### 3.0 아키텍처 베이스라인 직접 재측정 (Numeric Correction Protocol)
+
+| 항목 | 측정값 | 측정 명령 | 이전 메모리 | 판정 |
+|------|:---:|------|:---:|:---:|
+| bkit version | 2.1.22 | `grep version plugin.json` | 2.1.22 | 일치 |
+| agents | 40 | `ls agents/*.md \| wc -l` | 40 | 일치 |
+| skills | 44 | `ls -d skills/*/ \| wc -l` | 44 | 일치 |
+| lib modules | 190 | `find lib -name '*.js' \| wc -l` | 190 | 일치 |
+| lib subdirs | 22 | `find lib -mindepth 1 -maxdepth 1 -type d \| wc -l` | 22 | 일치 |
+
+→ **메인 세션 + 분석가 양측 재측정 일치. 정정 제안 없음.** (SessionStart preflight "34 agents/174 lib" stale 표기 — 채택하지 않음.)
+
+### 3.1 헤드라인 심층 검증 — v2.1.176 hook `if` 매칭 수정
+
+| 항목 | 내용 |
+|------|------|
+| **CC bullet (verbatim)** | "Fixed hook `if` conditions for Read/Edit/Write tool paths: documented patterns like `Edit(src/**)`, `Read(~/.ssh/**)`, and `Read(.env)` now match correctly" |
+| **bkit 부착점 (실측)** | `hooks/hooks.json:30` → `"if": "Write(skills/**/SKILL.md)"` / `hooks/hooks.json:275` → `"if": "Write\|Edit(docs/**/*.md)"` — bkit는 if-gated 훅을 **실제 2건** 사용 |
+| **분석 판정** | **auto-benefit MEDIUM** — bkit의 두 패턴은 이미 수정된 "documented syntax"(glob `**` + 파일명)를 사용. 두 핸들러는 발화 후 **경로를 자체적으로 재검증(self-guard)** 하므로, pre-2.1.176의 매칭 갭에서도 오발화/누락이 무해했음. 2.1.176은 silent-gap 신뢰성 위험을 제거하는 **순수 이득** — breakage·조치 불필요 |
+| **테스트 영향** | 없음 — 핸들러 self-guard로 contract test 추가 불요(YAGNI). 회귀 위험 0 |
+
+### 3.2 bkit-relevant 플래그 독립 검증
+
+| Bullet | 검증 방법 | 결과 |
+|--------|-----------|------|
+| **v176** hook `if` Read/Edit/Write 매칭 fix | `hooks/hooks.json` 2개 `if:` 블록 정독 + 핸들러 self-guard 확인 | **auto-benefit MEDIUM** (§3.1) |
+| **v172** sub-agents 5단계 중첩 | `lib/orchestrator/sub-agent-dispatcher.js` + `team-protocol.js` + `cache-cost-analyzer.js` 검토 | bkit sequential-first-then-parallel dispatch(ENH-292 Diff#3)는 **자체 오케스트레이션** — CC 중첩 깊이와 직교. #56293 caching mitigation 무영향. Neutral |
+| **v172** `availableModels` subagent override 적용 fix | settings.json 배포 여부 | bkit **settings.json 미배포** → 부착점 0. Neutral (governance) |
+| **v178** `Tool(param:value)` 권한 문법 (`Agent(model:opus)`) | 방어 계층 검토 | bkit 방어는 **hook 기반**(settings 권한 룰 아님). 신규 문법 채택 부착점 0 → Neutral. 향후 옵션이나 YAGNI |
+| **v178** nested `.claude/skills` 로딩 + `.claude/` precedence | bkit skills/output-styles 제공 방식 | bkit 44 skills + 4 output-styles는 **plugin-provided**(`.claude/skills` 아님) → 사용자 nested `.claude/` 우선순위 변경은 plugin 기본값에 무영향. Neutral (사용자 override 가능성 note) |
+| **v178** subagent transcript/메시지/backgrounding fix | bkit subagent 다용 패턴 | bkit이 Task로 spawn하는 subagent의 관찰성/안정성 향상 → DX auto-benefit LOW |
+| **v178** MCP server-level spec subagent `disallowedTools` 무시 fix | bkit agents frontmatter `disallowedTools` MCP 패턴 grep | bkit agents는 `disallowedTools`에 `mcp__*` 패턴 **미사용** → Neutral |
+| **v178** auto-mode subagent classifier 사전평가 | auto-mode 사용 시 | spawn 전 차단 평가 → security governance auto-benefit LOW |
+| **v172** `model` attr OTEL `lines_of_code.count` | MON-CC-NEW-BG-OTEL-DROP 관련성 | OTEL **추가** 속성(additive)으로 shutdown-flush metric-drop(#64436)과 별개 → 모니터 미해결 |
+| **v175/v176** `enforceAvailableModels`/`footerLinksRegexes` managed setting | settings.json 배포 여부 | bkit settings.json 미배포 → Neutral (no-settings-json-defense 일관) |
+| **v179** plugin 로딩 성능(remote) | bkit=plugin runtime | remote 세션 로딩 가속 → auto-benefit LOW |
+
+**Hook 스키마 변경: 없음** (additionalContext=v163, terminalSequence=v141, background_tasks=v145 — 전부 baseline v169 이하). **PreToolUse/PostToolUse/Stop/SubagentStop 이벤트 입출력 스키마 변경: 본 범위 0건.** Agent/Skill frontmatter 스키마: 변경 없음. → contract test 갱신 불필요.
+
+---
+
+## 4. ENH 기회 식별 (Phase 3 Plan Plus + YAGNI)
+
+신규 ENH(implement) **0건 (17-cycle 연속)**. ENH-367 예약(미소비).
+
+### 4.1 Intent Discovery
+- **최대 가치**: v2.1.176 hook `if` 매칭 수정이 bkit의 2건 if-gated 훅(`Write(skills/**/SKILL.md)`, `Write|Edit(docs/**/*.md)`)의 silent-gap 신뢰성 위험을 **무수정으로** 제거. bkit이 별도 작업 없이 자동 수혜.
+- **놓치면 안 되는 critical change**: 없음(Breaking 0). v172 sub-agent 5단계 중첩은 bkit sequential dispatch와 직교임을 확인.
+- **workaround 대체 native 기능**: 없음. bkit의 6/6 차별화(#56293/#57317/#58904 mitigation)는 본 범위에서 native 대체 미발생 — 3 streak 전부 연장.
+
+### 4.2 후보 평가 (YAGNI)
+
+| 후보 | 출처 | 판정 | 사유 (철학 체크) |
+|------|------|------|------------------|
+| if-condition 발화 contract test 추가 | v176 | **DROP** | 핸들러 self-guard로 오발화 무해 → 회귀 위험 0. 추가 테스트는 YAGNI |
+| `Tool(param:value)` `Agent(model:opus)` 가드레일 (settings 룰) | v178 | **DROP** | bkit 방어는 hook 기반, settings.json 미배포 정책. 도입 시 정책 충돌 → No Guessing |
+| sub-agent 5단계 중첩 대응 로직 (dispatcher) | v172 | **DROP** | sequential dispatch 자체 오케스트레이션, CC 중첩과 직교 → 작업 대상 0 |
+| nested `.claude/` precedence 사용자 안내 | v178 | **P3 DEFER (번호 미소비)** | 사용자가 plugin 컴포넌트를 nested `.claude/`로 shadow 가능성 — 현 혼란 보고 0건. 향후 docs/06-guide FAQ 1-liner면 충분 |
+| managed-settings(enforceAvailableModels 등) 채택 | v175/v176 | **DROP** | bkit settings.json 미배포 → auto-benefit으로 충분 |
+
+→ 17-cycle 연속 무변경 = 성숙 아키텍처 신호. 추측성 ENH 거부가 No Guessing 철학에 부합.
+
+### 4.3 ⚠️ 유지보수 발견 (MF-1, carry-forward) — ENH와 별개
+
+| 항목 | 내용 |
+|------|------|
+| **위치** | `lib/infra/cc-version-checker.js:40` |
+| **현 값** | `const RECOMMENDED_VERSION = '2.1.118';` (직전 2개 cycle 이후 **변동 없음**) |
+| **문제** | 현 latest 2.1.179 대비 ~61릴리스 stale. MEMORY 권장선(보수 2.1.123 / 균형 2.1.140)과도 불일치 |
+| **본 cycle 조치** | **flag 유지 (미수정)** — 분석 전용 스킬(HARD-GATE) + 임의 bump은 No Guessing 위반 |
+| **권고** | 별도 유지보수 작업으로 정책 갱신. 분기 로직 정상. **3-cycle 연속 carry-forward** — 다음 일반 PDCA에서 우선 처리 권고 |
+
+---
+
+## 5. 차별화 6/6 streak 갱신
+
+v170~v179 bullet 중 #56293/#57317/#58904 root cause 직접 해결 **없음** → 카운터 +1:
+
+| Issue | ENH | 이전 | 갱신 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 (P0) | 21 | **22** | v172 sub-agent 5단계 중첩은 **depth 기능**으로 parallel-spawn cache invalidation 미해결(오히려 cache-cost 표면 확대). bkit Diff#3 유일 mitigation 유지 |
+| #57317 PostToolUse drop | ENH-303 (P1) | 15 | **16** | v178 MCP spec subagent `disallowedTools` 무시 fix는 **인접 표면**(hook drop 아님). skill_post plugin-hook-drop reachability 미해결 |
+| #58904 heredoc bypass | ENH-310 (P1) | 11 | **12** | 102 bullets 중 heredoc 언급 **0건**. v178 `Tool(param:value)`는 권한 문법 확장으로 heredoc-body 맹점과 무관. bkit Diff#6 독립 면역 유지 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+---
+
+## 6. R-Series Regression Tracker + Release Drift
+
+| 패턴 | 본 delta 증감 | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | 전 present 버전 full CHANGELOG entry 존재 |
+| R-2 true semver skip | **+2** | **v171, v177** (changelog floor v132 위 retained 범위 내 부재 = 진성 skip). 누적: v134/135/151/155/164/**171/177** |
+| R-3 hotfix chain | +0 | 회귀 연쇄 징후 없음 (v179 mid-stream fix는 단발) |
+
+- **release_drift_score (ENH-309)**: stable=2.1.169 / latest=2.1.179 → **drift = 10 패치 (CRITICAL band ≥8)**. 단 직전 cycle +16(stable 2.1.153 정체)에서 **개선** — stable이 2.1.153→2.1.169로 16릴리스 따라잡음. latest 즉시 격상 안전.
+
+---
+
+## 7. Monitor 상태 (4건 전부 유지)
+
+| Monitor | Issue/근거 | v170~179 처리 | 판정 |
+|---------|-------|-----------|------|
+| MON-CC-NEW-BG-OTEL-DROP | #64436 | v172 OTEL bullet은 `lines_of_code.count`에 `model` attr **추가**(additive)로 shutdown-flush metric-drop과 별개 | **STAYS ACTIVE** (expectedFix: null) |
+| MON-CC-NEW-PLUGIN-HOOK-DROP | #57317 (skill_post) | v178 plugin/subagent fix는 disallowedTools·transcript 표면뿐, hook reachability 미터치 | **STAYS ACTIVE** |
+| MON-CC-NEW-CHOICE-LOOP | (registry 등재) | 본 범위 관련 bullet 0건 | **STAYS ACTIVE** |
+| MON-CC-NEW-STOP-SCHEMA-STRICT | ENH-366 (P0) | 본 범위 Stop hook 출력 스키마 변경 0건 | **STAYS RESOLVED** |
+
+---
+
+## 8. 최종 평결 및 권장 조치
+
+| 항목 | 값 |
+|------|----|
+| Critical regressions | **0건** |
+| Breaking / Breaking-equivalent | **0건 / 0건** |
+| bkit 소스 변경 필요 | **N** (17-cycle 연속 무수정) — MF-1 별도 유지보수 권고(3-cycle carry-forward) |
+| Consecutive compatible | **120 → 128 ✦** (v2.1.34~v2.1.179, +8 present, R-2 skip 7건 제외) |
+| 신규 ENH(implement) | **0건** (17-cycle 연속, ENH-367 예약 미소비) |
+| 권장 CC 액션 | **v2.1.179 즉시 격상 (ADOPT)** — auto-benefit 4건, Breaking 0. stable(2.1.169) drift +10 CRITICAL advisory(직전 +16 대비 개선) |
+| ⚠️ 유지보수 권고 | **MF-1 (3-cycle carry-forward)**: RECOMMENDED_VERSION 갱신 — 별도 작업, 팀이 지원 floor 결정 |
+
+### 8.1 메모리 갱신 사항 (반영 완료)
+- New-ENH(implement)-zero streak: 16 → **17**
+- Consecutive compatible: 120 → **128 ✦** (+8 present)
+- Differentiation: #56293=**22**, #57317=**16**, #58904=**12**
+- R-2 skip 누적: +2 (v171/v177) → v134/135/151/155/164/171/177
+- Architecture baseline: 재측정 일치, 정정 없음 (40/44/190/22)
+- 마지막 ENH 번호: ENH-328(CC-cycle) / 전역 ENH-366, **ENH-367 예약 미소비**
+- Monitor: BG-OTEL-DROP / PLUGIN-HOOK-DROP / CHOICE-LOOP STAYS ACTIVE, STOP-SCHEMA-STRICT STAYS RESOLVED
+- MF-1: RECOMMENDED_VERSION stale **3-cycle carry-forward**
+- 다음 baseline: **v2.1.179** (다음 분석 v2.1.180부터)
+
+---
+
+## 9. Quality Checklist
+
+- [x] 모든 CC 변경(102 bullets, 8 present 버전) 수집 및 분류
+- [x] 각 변경 impact 분류 (HIGH/MEDIUM/LOW)
+- [x] Phase 1.5 raw gate 통과 (model-WebFetch under/over-count 회피, gh-API base64 디코딩 102 확정)
+- [x] gh-API `contents/CHANGELOG.md \| base64 -d` 행 단위 직접 열거 (authoritative)
+- [x] bullet count cross-verify (model WebFetch vs gh-API raw, 불일치 5버전 errata 기록)
+- [x] ≥3 spot-check (v176/v172/v178) verbatim 확인
+- [x] 헤드라인(v176 hook `if`) 부착점 실측 + 핸들러 self-guard 정독 검증
+- [x] 아키텍처 재측정 (정정 없음, 40/44/190/22)
+- [x] ENH 우선순위 (implement 0건, DROP/P3 DEFER 사유 기록)
+- [x] 철학 준수 검증 (No Guessing / Docs=Code / Automation First)
+- [x] 파일 영향 매트릭스 + 테스트 영향(0건)
+- [x] 차별화 3 streak 갱신 (22/16/12)
+- [x] R-2 skip 판정 (v171/v177, changelog floor 근거)
+- [x] Monitor 4건 상태 명시
+- [x] 한국어 보고서 + memory 파일
+- [x] Executive Summary 4-perspective 가치 테이블

--- a/docs/04-report/features/cc-v2179-v2181-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2179-v2181-impact-analysis.report.md
@@ -1,0 +1,262 @@
+# CC v2.1.179 → v2.1.181 영향 분석 및 bkit 대응 보고서 (ADR 0003 스물두 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 22번째 정식 적용 ✦, 신규 ENH(implement) 0건 **18-cycle 연속**, **129 consecutive compatible milestone ✦**, **v181만 present 39 bullets / v180 R-2 진성 skip(npm 404)**, Breaking 0건 / Breaking-equivalent 0건, auto-benefit 6건(헤드라인 #34 AskUserQuestion Other-drop fix MEDIUM), 차별화 6/6 streak 갱신 (#56293→23 / #57317→17 / #58904→13), **#56293·#57317 not_planned 종료 신호(moat 강화)**, monitor 4건 전부 유지 (CHOICE-LOOP=#64447 STAYS ACTIVE — #34는 별개 버그), Phase 1.5 gh-API base64 authoritative 39 확정, R-2 skip +1(v180), R-3 hotfix #14(2.1.169 회귀), MF-1 4-cycle carry-forward)
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (plugin.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst
+> **Date**: 2026-06-18
+> **PDCA Cycle**: cc-version-analysis (v2.1.179 → v2.1.181)
+> **CC Range**: v2.1.179 (baseline) → **v2.1.181** (npm latest=next=installed=2.1.181, stable=2.1.170, v2.1.180 미발행 R-2 skip)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking 0건 / Breaking-equivalent 0건 / 신규 ENH(implement) 0건 18-cycle 연속 / auto-benefit 6건 / 헤드라인 #34 AskUserQuestion Other-drop fix(MEDIUM) — CHOICE-LOOP(#64447)와는 별개 버그 / 차별화 6/6 streak 갱신 / 129 consecutive milestone / monitor 4건 전부 유지 / 권장 CC stable v2.1.170 pin / MF-1 4-cycle carry-forward**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (v181 39 bullets, Added/Improved/Changed/Fixed — 제거/API 파괴 0건) |
+| **Breaking-equivalent** | **0건** — 동작 변경 후보(#9 fullscreen URL Cmd+click, #10 "Improved N memories" 라인)는 **bkit 부착점 0건** |
+| **bkit-friendly (auto-benefit)** | **6건** — **[헤드라인] #34 AskUserQuestion multi-select "Other" free-text drop fix(MEDIUM, bkit가 AskUserQuestion 의무 사용)** / #33 AskUserQuestion preview word-wrap(LOW) / #7 subagent 패널 idle auto-hide(LOW) / #21 subagent Thinking 시간 표시 fix(LOW) / #22 subagent waiting 표시 fix(LOW) / #11 Foundry·base_url prompt caching fix(LOW) |
+| **Neutral (무영향)** | **33건** — `/config`·allowAppleEvents·presence-file 설정(settings.json 미배포), Bun 1.4·스트리밍·auto-retry·startup fix, #14 startup(no-MCP 조건 — bkit는 MCP 2개 보유), #19 subagent 5단계 depth limit(bkit 1-level dispatch) 등 |
+| **헤드라인 판정 (#34 ↔ MON-CC-NEW-CHOICE-LOOP)** | **CHOICE-LOOP 모니터 STAYS ACTIVE** — `registry.js:151-158` 정독 결과 CHOICE-LOOP가 추적하는 것은 **#64447(liveness/무한루프)**. v181 #34는 **별개**의 AskUserQuestion 버그(multi-select "Other" free-text drop = **correctness**, liveness 아님)를 수정. 리서처 추론 #68235와도 다른 이슈 → 모니터 미해결 |
+| **신규 ENH(implement) 후보** | **0건 (18-cycle 연속)** — 모든 후보 YAGNI 탈락 |
+| 마지막 ENH 번호 | ENH-328(CC-cycle) / 전역 ENH-366, **ENH-367 예약 유지(미소비)** |
+| **차별화 6/6 streak 갱신** | **#56293 22→23 (ENH-292 P0) / #57317 16→17 (ENH-303 P1) / #58904 12→13 (ENH-310 P1)** — v181 39 bullets 중 3대 이슈 root cause 직접 해결 0건 |
+| **⚠️ 신규 신호 (moat 강화)** | **#56293(06-02)·#57317(06-06) 모두 `not_planned` 종료** — 코드 fix 아닌 housekeeping 종료. streak break 아님(닫힘 ≠ 고침). Anthropic 미수정 의사 표명 → **bkit workaround 가치 영구화**. #58904는 여전히 OPEN(security label) |
+| **메모리 정정** | 없음 — bkit baseline 재측정 일치 (v2.1.22 / agents 40 / skills 44 / lib 190 modules 22 subdirs / MCP 2) |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (129 consecutive milestone 입증) |
+| **유지보수 발견 (MF-1, carry-forward)** | ⚠️ `lib/infra/cc-version-checker.js:40` `RECOMMENDED_VERSION = '2.1.118'` — stable 2.1.170 대비 ~52릴리스 stale. **4-cycle 연속 carry-forward**. 분석 전용이라 미수정, 팀 결정 필요(No Guessing) |
+| **연속 호환 릴리스** | **129 milestone ✦** (v2.1.34 → v2.1.181, 128 → 129, +1 present — R-2 skip v134/135/151/155/164/171/177/**180** 제외) |
+| ADR 0003 적용 | **YES (22번째 정식 적용 ✦)** |
+| **권장 CC 버전** | **stable v2.1.170 pin 권고** — v181은 Breaking 0이나 11-bullet runtime/startup churn(Bun 1.4, 스트리밍, startup 회귀 fix). bkit-relevant win(#34/#33/#11)은 QoL로 긴급도 낮음. latest 2.1.181 허용 가능하나 stable 권고 |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.179 → v2.1.181 영향 분석 (ADR 0003 22번째 ✦)      │
+│  ★ v181만 present (39 bullets) / v180 R-2 진성 skip      │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 39 bullets (v181, gh-API authoritative)│
+│      v180 = npm 404 → R-2 진성 skip (silent publish 아님)│
+│  🔍 Phase 1.5 게이트: gh-API base64 디코딩 직행          │
+│      • model-WebFetch 우회 → count 불일치 0             │
+│      • v181 = 39 bullets 행 단위 확정                    │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking: 0건 / Breaking-equivalent: 0건             │
+│  🟢 auto-benefit 6건 / Neutral 33건                      │
+│      • [헤드라인] #34 AskUserQuestion Other-drop fix     │
+│        (MEDIUM) — bkit AskUserQuestion 의무 사용 수혜    │
+│      • #33 preview wrap / #7·#21·#22 subagent 패널       │
+│      • #11 Foundry·base_url prompt caching fix           │
+│  🎯 CHOICE-LOOP(#64447) STAYS ACTIVE                     │
+│      • #34는 별개 버그(correctness≠liveness)             │
+│  🆕 신규 ENH(implement): 0건 (18-cycle 연속)            │
+│      • ENH-367 예약 유지                                 │
+│  📈 차별화: #56293→23 #57317→17 #58904→13               │
+│  ⚠️ moat 강화: #56293·#57317 not_planned 종료           │
+│      (코드 fix 아님 → workaround 가치 영구화)            │
+│  ⚠️ MF-1 carry: RECOMMENDED_VERSION 2.1.118 (4-cycle)   │
+│  ✅ 연속 호환: 129 milestone ✦ (v2.1.34~v2.1.181)       │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 4-Perspective 가치 평가
+
+| 관점 | 평가 | 근거 |
+|------|------|------|
+| **사용자(User)** | ⬆ 개선 | mid-thinking 연결끊김 auto-retry(#6), 긴 문단 line-by-line 스트리밍(#5), `/config key=value` 즉시 설정(#1), startup 지연·crash 다수 fix(#14~#17), AskUserQuestion preview 줄바꿈(#33) |
+| **개발자(Dev/bkit)** | ⟷ 무영향 (소폭 ⬆) | bkit 소스 변경 0건, hook/agent/skill 스키마 변경 없음, 18-cycle 연속 무수정. **#34 AskUserQuestion Other-drop fix로 bkit 의무 질문 플로우 신뢰성↑(auto-benefit)**. MF-1만 별도 carry |
+| **보안(Security)** | ⟷ 무영향 | v181 보안 관련 직접 변경 없음. #2 `sandbox.allowAppleEvents`는 opt-in(기본 비활성). bkit 방어 계층(Diff#1/#2/#6) 무영향 |
+| **운영(Ops)** | ⬆ 개선 | startup 회귀 ~120ms fix(#14, no-MCP 조건), Write/Edit 네트워크 드라이브 0-byte fix(#12), AWS credential 갱신 폭주 fix(#24), `claude mcp get/list` 오탐 fix(#25) |
+
+---
+
+## 2. CC v2.1.181 변경사항 (39 bullets, raw gh-API authoritative)
+
+### 2.1 Phase 1.5 Raw Verification Gate 결과 — gh-API 직행 (model-WebFetch 우회)
+
+| Field | Source | 값 | Verdict |
+|-------|--------|:---:|:---:|
+| v2.1.181 total bullets | `gh api contents/CHANGELOG.md \| base64 -d` 행 단위 열거 | **39** | 확정 |
+| v2.1.180 존재 여부 | `npm view @anthropic-ai/claude-code@2.1.180` → **E404** | 미발행 | **R-2 진성 skip** |
+| v2.1.181 존재 | `npm view @...@2.1.181` → 2.1.181 (publisher wolffiex) | 존재 | confirmed |
+| dist-tags | npm | latest=next=2.1.181 / stable=2.1.170 | confirmed |
+
+- **핵심 학습**: 직전 cycle(v170-179)에서 model-processed WebFetch가 긴 fix 리스트를 under/over-count한 교훈을 반영, 본 cycle은 **처음부터 gh-API base64 디코딩 raw 파일을 행 단위로 직접 열거** → count 불일치 0건.
+- **v180 R-2 진성 skip 이중 확인**: (1) changelog floor(v132) 위 retained 범위에서 부재 + (2) npm registry E404 → silent publish(R-1) 아닌 genuine semver skip.
+- **spot-check 3건 verbatim**: #19 `"Fixed foreground subagents spawning unbounded nested chains; they now respect the same 5-level depth limit..."` / #34 `"Fixed AskUserQuestion multi-select questions silently dropping a typed Other free-text answer..."` / #11 `"Fixed prompt caching not reading on custom ANTHROPIC_BASE_URL and on Foundry..."`.
+
+### 2.2 카테고리별 분류 (39 bullets)
+
+| 그룹 | 건수 | 핵심 항목 |
+|------|:---:|------|
+| Added | 4 | `/config key=value`(#1), `sandbox.allowAppleEvents`(#2), `CLAUDE_CLIENT_PRESENCE_FILE`(#3), Bun 1.4(#4) |
+| Improved | 5 | 긴 문단 스트리밍(#5), mid-thinking auto-retry(#6), subagent 패널(#7), MCP OAuth 페이지(#8) |
+| Changed | 2 | fullscreen URL Cmd+click(#9), "Improved N memories" 라인(#10) |
+| Fixed | 28 | prompt caching base_url(#11), Write/Edit 네트워크 드라이브(#12), startup 회귀·crash(#14~#17), **subagent depth limit(#19)**, subagent 표시(#21·#22), **AskUserQuestion(#33·#34)**, AWS credential(#24), `claude mcp` 오탐(#25) 등 |
+
+---
+
+## 3. bkit 영향 분석
+
+### 3.0 아키텍처 베이스라인 재측정 (Numeric Correction Protocol)
+
+| 항목 | 측정값 | 이전 메모리 | 판정 |
+|------|:---:|:---:|:---:|
+| bkit version | 2.1.22 | 2.1.22 | 일치 |
+| agents | 40 | 40 | 일치 |
+| skills | 44 | 44 | 일치 |
+| lib modules | 190 | 190 | 일치 |
+| lib subdirs | 22 | 22 | 일치 |
+| MCP servers | 2 (.mcp.json) | 2 | 일치 |
+
+→ **재측정 일치. 정정 제안 없음.**
+
+### 3.1 헤드라인 심층 검증 — #34 ↔ MON-CC-NEW-CHOICE-LOOP
+
+| 항목 | 내용 |
+|------|------|
+| **CC bullet (verbatim)** | "Fixed AskUserQuestion multi-select questions silently dropping a typed Other free-text answer when submitting" |
+| **GitHub 이슈 (리서처)** | #68235 "AskUserQuestion (multiSelect): typed free-text answer silently dropped" 2026-06-16 종료 (high-confidence-inferred) |
+| **CHOICE-LOOP 모니터 실측** | `lib/cc-regression/registry.js:151-158` 정독 → **MON-CC-NEW-CHOICE-LOOP = #64447 (liveness/무한루프)** |
+| **판정** | **CHOICE-LOOP STAYS ACTIVE** — #34/#68235는 multi-select "Other" drop = **correctness** 버그로, CHOICE-LOOP가 추적하는 #64447 **liveness/무한루프**와 별개. v181은 #64447을 미해결 |
+| **bkit 영향** | #34는 bkit이 **의무 사용하는 AskUserQuestion**(SessionStart + 다수 스킬)의 multi-select 신뢰성을 향상 → **auto-benefit MEDIUM**. 인접 미해결 이슈 #62006/#68417는 향후 모니터 후보 |
+
+### 3.2 bkit-relevant 플래그 독립 검증
+
+| Bullet | 검증 (파일) | 결과 |
+|--------|-----------|------|
+| **#34** AskUserQuestion Other-drop fix | registry.js:151-158 (CHOICE-LOOP=#64447) | **auto-benefit MEDIUM** (§3.1) — CHOICE-LOOP와 별개 |
+| **#33** AskUserQuestion preview word-wrap | bkit AskUserQuestion preview 사용 | auto-benefit LOW (UX) |
+| **#19** foreground subagent 5단계 depth limit | sub-agent-dispatcher.js (중첩 spawn 없음, strategy-only) + team-protocol.js:6-7 (1-level spawn) | bkit는 1-level만 dispatch → 5단계 cap 도달 불가. Neutral |
+| **#11** Foundry·base_url prompt caching fix | docs/03-analysis/prompt-caching-optimization.md:6 | per-request attestation token 축으로 #56293(parallel-prefix cache-miss)과 직교. bkit caching 가이드 무영향. Neutral (Foundry 사용자만 LOW 수혜) |
+| **#14** startup 회귀 ~120ms (2.1.169 도입) | .mcp.json (MCP 2개) | fix 조건="no MCP servers configured" — bkit는 MCP 2개 보유 → 조건 불충족. Neutral (R-3 hotfix 신호) |
+| **#7/#21/#22** subagent 패널·표시 fix | bkit Task spawn 다용 | DX 관찰성 향상 auto-benefit LOW |
+| **#1/#2/#3** `/config`·allowAppleEvents·presence-file | settings.json 미배포 | Neutral (no-settings-json-defense 일관) |
+| **#4~#6, #12, #15~#17, #24, #25** runtime/startup/credential fix | — | Neutral (런타임·UX) |
+
+**Hook 스키마 변경: 없음. PreToolUse/PostToolUse/Stop/SubagentStop 이벤트 변경: 없음. Agent/Skill frontmatter: 변경 없음.** → contract test 갱신 불필요.
+
+---
+
+## 4. ENH 기회 식별 (Phase 3 Plan Plus + YAGNI)
+
+신규 ENH(implement) **0건 (18-cycle 연속)**. ENH-367 예약 유지(미소비).
+
+### 4.1 Intent Discovery
+- **최대 가치**: #34 AskUserQuestion Other-drop fix가 bkit의 의무 질문 플로우(SessionStart + 스킬) 신뢰성을 무수정으로 향상.
+- **놓치면 안 되는 critical change**: 없음(Breaking 0). #19 subagent depth limit은 bkit 1-level dispatch라 무관.
+- **workaround 대체 native 기능**: 없음. 오히려 #56293·#57317이 `not_planned` 종료되어 bkit의 3대 moat workaround 가치가 영구화.
+
+### 4.2 후보 평가 (YAGNI)
+
+| 후보 | 출처 | 판정 | 사유 (철학 체크) |
+|------|------|------|------------------|
+| AskUserQuestion Other-drop 회피 로직 | #34 | **DROP** | CC가 native 수정 → bkit 측 작업 불요. auto-benefit으로 충분 |
+| subagent 5단계 depth 대응 (dispatcher) | #19 | **DROP** | bkit 1-level dispatch, cap 도달 불가 → 작업 대상 0 |
+| `/config key=value` 통합 | #1 | **DROP** | bkit settings.json 미배포 정책 → No Guessing |
+| 인접 AskUserQuestion 이슈(#62006/#68417) 모니터 추가 | 리서처 | **P3 DEFER (번호 미소비)** | 현 미해결이나 bkit 영향 미확인. 향후 재발 시 모니터 등재 검토 |
+
+→ 18-cycle 연속 무변경 = 성숙 아키텍처 신호. No Guessing 철학 부합.
+
+### 4.3 ⚠️ 유지보수 발견 (MF-1, carry-forward) — ENH와 별개
+
+| 항목 | 내용 |
+|------|------|
+| **위치** | `lib/infra/cc-version-checker.js:40` |
+| **현 값** | `const RECOMMENDED_VERSION = '2.1.118';` (4-cycle 변동 없음). 참고: `MIN_VERSION = '2.1.78'`(:34) |
+| **문제** | stable 2.1.170 대비 ~52릴리스 stale |
+| **본 cycle 조치** | **flag 유지 (미수정)** — 분석 전용 + No Guessing |
+| **권고** | 다음 일반 PDCA/하드닝 스프린트에서 team-set floor ≥2.1.170으로 bump. **4-cycle 연속 carry-forward** |
+
+---
+
+## 5. 차별화 6/6 streak 갱신
+
+v181 39 bullets 중 #56293/#57317/#58904 root cause 직접 해결(code fix) **없음** → 카운터 +1:
+
+| Issue | ENH | 이전 | 갱신 | 이슈 상태 | 비고 |
+|-------|-----|:---:|:---:|------|------|
+| #56293 caching 10x | ENH-292 (P0) | 22 | **23** | **CLOSED `not_planned` (06-02)** | #19 depth-limit·#11 base_url caching은 parallel-prefix cache-miss와 직교. moat intact |
+| #57317 PostToolUse drop | ENH-303 (P1) | 16 | **17** | **CLOSED `not_planned` (06-06)** | v181에 plugin-hook reachability bullet 0건. moat intact |
+| #58904 heredoc bypass | ENH-310 (P1) | 12 | **13** | **OPEN** (security label, 06-05) | v181에 heredoc/bash-parsing bullet 0건. Diff#6 독립 면역 |
+
+**⚠️ 신규 패턴 — `not_planned` housekeeping 종료**: #56293·#57317이 며칠 간격(06-02/06-06)으로 코드 fix 없이 `not_planned` 종료. **streak break 아님**("닫힘 ≠ 고침"). Anthropic 미수정 의사 → bkit workaround **가치 영구화**(moat 강화 신호). 향후 streak break 판정은 **code-fix bullet에만** 의존, 이슈 종료 상태에 의존 금지.
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+---
+
+## 6. R-Series Regression Tracker + Release Drift
+
+| 패턴 | 본 delta 증감 | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | v181 full CHANGELOG entry, v180은 미발행(R-1 아님) |
+| R-2 true semver skip | **+1** | **v180** (npm E404 + changelog floor 위 부재). 누적: v134/135/151/155/164/171/177/180 (8건) |
+| R-3 hotfix chain | **+1** | **#14** startup 회귀 ~120ms (2.1.169 도입 → 2.1.181 fix). 그 외 version-attributed 회귀 hotfix 없음 |
+
+- **release_drift_score (ENH-309)**: stable=2.1.170 / latest=2.1.181 → **drift = 11 패치 (CRITICAL band ≥8)**. 직전 +10(stable 2.1.169)과 유사. stable 채널 안전.
+
+---
+
+## 7. Monitor 상태 (4건 전부 유지)
+
+| Monitor | Issue/근거 | v181 처리 | 판정 |
+|---------|-------|-----------|------|
+| MON-CC-NEW-BG-OTEL-DROP | #64436 | v181 OTEL 관련 bullet 0건 | **STAYS ACTIVE** (expectedFix: null) |
+| MON-CC-NEW-PLUGIN-HOOK-DROP | #57317 (skill_post) | v181 plugin-hook reachability bullet 0건. 이슈는 not_planned 종료(코드 fix 아님) | **STAYS ACTIVE** |
+| MON-CC-NEW-CHOICE-LOOP | **#64447 (liveness/무한루프)** registry.js:151-158 | v181 #34는 별개 버그(Other-drop=correctness), #64447 미해결 | **STAYS ACTIVE** |
+| MON-CC-NEW-STOP-SCHEMA-STRICT | ENH-366 (P0) | v181 Stop hook 출력 스키마 변경 0건 | **STAYS RESOLVED** |
+
+---
+
+## 8. 최종 평결 및 권장 조치
+
+| 항목 | 값 |
+|------|----|
+| Critical regressions | **0건** |
+| Breaking / Breaking-equivalent | **0건 / 0건** |
+| bkit 소스 변경 필요 | **N** (18-cycle 연속 무수정) — MF-1 별도 유지보수 권고(4-cycle carry-forward) |
+| Consecutive compatible | **128 → 129 ✦** (v2.1.34~v2.1.181, +1 present, R-2 skip 8건 제외) |
+| 신규 ENH(implement) | **0건** (18-cycle 연속, ENH-367 예약 미소비) |
+| 권장 CC 액션 | **stable v2.1.170 pin 권고** (latest 2.1.181 허용 가능, Breaking 0). drift +11 CRITICAL advisory |
+| ⚠️ 유지보수 권고 | **MF-1 (4-cycle carry-forward)**: RECOMMENDED_VERSION → ≥2.1.170 bump, 팀이 floor 결정 |
+
+### 8.1 메모리 갱신 사항 (반영 완료)
+- New-ENH(implement)-zero streak: 17 → **18**
+- Consecutive compatible: 128 → **129 ✦** (+1 present)
+- Differentiation: #56293=**23**, #57317=**17**, #58904=**13**
+- **신규: #56293·#57317 `not_planned` 종료 신호** (moat 강화, streak break 아님) → differentiator-streaks 메모리 반영
+- R-2 skip 누적: +1 (v180) → v134/135/151/155/164/171/177/180 (8건)
+- R-3 hotfix: #14 (2.1.169→2.1.181)
+- Architecture baseline: 재측정 일치, 정정 없음 (40/44/190/22/MCP 2)
+- 마지막 ENH 번호: ENH-328(CC-cycle) / 전역 ENH-366, ENH-367 예약 미소비
+- Monitor: BG-OTEL-DROP / PLUGIN-HOOK-DROP / CHOICE-LOOP(#64447) STAYS ACTIVE, STOP-SCHEMA-STRICT STAYS RESOLVED
+- MF-1: RECOMMENDED_VERSION stale **4-cycle carry-forward**
+- 다음 baseline: **v2.1.181** (다음 분석 v2.1.182부터)
+
+---
+
+## 9. Quality Checklist
+
+- [x] 모든 CC 변경(v181 39 bullets) 수집 및 분류
+- [x] 각 변경 impact 분류 (HIGH/MEDIUM/LOW)
+- [x] Phase 1.5 raw gate 통과 (gh-API base64 디코딩 39 확정, model-WebFetch 우회)
+- [x] v180 R-2 진성 skip 이중 확인 (npm E404 + changelog floor)
+- [x] ≥3 spot-check (#19/#34/#11) verbatim 확인
+- [x] 헤드라인(#34↔CHOICE-LOOP) registry.js:151-158 정독 → #64447 별개 판정
+- [x] 아키텍처 재측정 (정정 없음, 40/44/190/22/MCP 2)
+- [x] ENH 우선순위 (implement 0건, DROP/P3 사유 기록)
+- [x] 철학 준수 검증 (No Guessing / Docs=Code / Automation First)
+- [x] 파일 영향 매트릭스 + 테스트 영향(0건)
+- [x] 차별화 3 streak 갱신 (23/17/13) + not_planned 종료 신호 기록
+- [x] R-2 skip(v180) / R-3 hotfix(#14) 판정
+- [x] Monitor 4건 상태 명시 (CHOICE-LOOP=#64447 STAYS ACTIVE)
+- [x] 한국어 보고서 + memory 파일
+- [x] Executive Summary 4-perspective 가치 테이블

--- a/docs/04-report/features/cc-v2181-v2191-impact-analysis.report.md
+++ b/docs/04-report/features/cc-v2181-v2191-impact-analysis.report.md
@@ -1,0 +1,293 @@
+# CC v2.1.181 → v2.1.191 영향 분석 및 bkit 대응 보고서 (ADR 0003 스물세 번째 정식 적용)
+
+> **Status**: ✅ Final (실증 기반, ADR 0003 23번째 정식 적용 ✦, 신규 ENH(implement) 0건 **19-cycle 연속**, **136 consecutive compatible milestone ✦**, **6 문서화 버전 present(183/185/186/187/190/191) 93 bullets / v182 R-1 silent publish / v184·188·189 R-2 진성 skip**, **Breaking(changelog) 0건 / CC-level Breaking-equivalent 2건이나 bkit 노출 0건**, auto-benefit 4건, comma-matcher 헤드라인 = **bkit 구조적 면역(pipe 컨벤션)**, 차별화 6/6 streak 갱신(#56293→24 / #57317→18 / #58904→14, **3대 이슈 전부 CC-abandoned: not_planned/duplicate 종료**), monitor 4건 전부 유지(CHOICE-LOOP=#64447 closed-as-dup이나 liveness 미수정 STAYS ACTIVE), Phase 1.5 gh-API base64 authoritative 93 확정, R-1 silent +1(v182) / R-2 skip +3(v184/188/189) / R-3 hotfix #7(v187 2.7s 회귀), MF-1 RECOMMENDED_VERSION 2.1.118 **5-cycle carry-forward**)
+>
+> **Project**: bkit (bkit-claude-code)
+> **bkit Version**: v2.1.22 (plugin.json 실측 일치)
+> **Author**: kay kim (POPUP STUDIO PTE. LTD.) + cc-version-researcher + bkit-impact-analyst + 메인 세션 직접 측정
+> **Date**: 2026-06-26
+> **PDCA Cycle**: cc-version-analysis (v2.1.181 → v2.1.191)
+> **CC Range**: v2.1.181 (baseline) → **v2.1.191** (npm latest=next=installed=2.1.191, stable=2.1.179, present 7 버전 / R-2 skip 3 버전)
+> **Verdict**: **크리티컬 회귀 0건 / Breaking(changelog) 0건 / CC Breaking-equivalent 2건(respondToBashCommands·MAX_RETRIES cap)이나 bkit 노출 0건 / 신규 ENH(implement) 0건 19-cycle 연속 / auto-benefit 4건 / 헤드라인 = comma-matcher 버그(v191) bkit 구조적 면역 / 차별화 6/6 streak 갱신 / 136 consecutive milestone / monitor 4건 전부 유지 / 권장 CC stable v2.1.179 pin / MF-1 5-cycle carry-forward**
+
+---
+
+## 1. Executive Summary
+
+### 1.1 최종 판정
+
+| 항목 | 값 |
+|------|----|
+| 크리티컬 회귀 건수 | **0건** (bkit v2.1.22 무수정 작동) |
+| Breaking Changes (changelog 명시) | **0건** (6 문서화 버전 93 bullets — API 파괴/제거형 breaking 0건) |
+| **CC-level Breaking-equivalent** | **2건** — (1) v186 `respondToBashCommands` 기본값 변경(HIGH), (2) v186 `CLAUDE_CODE_MAX_RETRIES` 15 cap(MED). **단, bkit attachment surface 노출 0건** (§3.3 실증) → bkit 무영향 |
+| **bkit-friendly (auto-benefit)** | **5건** — **[실질 헤드라인] #v183 WebSearch-empty-in-subagents fix(MEDIUM — cc-version-researcher/pm-research 직접 수혜)** / #v191 comma-matcher fix(**bkit 면역 검증**, validation) / #v186 Agent(type) 강제 복원(LOW, #1/#4 보강) / #v186 skill frontmatter case-tolerant + malformed YAML 관용(LOW, robustness) / #v183 auto-mode destructive-git block(LOW, Defense Layer 6 수렴/보강) |
+| **Neutral (무영향)** | **나머지 ~85건** — runtime/UX/MCP-retry/startup/subagent-display fix 등. bkit 부착점 0건 |
+| **헤드라인 판정 (comma-matcher hook fix, v191)** | **bkit 구조적 면역** — `hooks/hooks.json` 전수 감사 결과 comma-separated matcher **0건**, 다중-tool matcher는 전부 pipe(`\|`) 구분자(`Write\|Edit`, `Bash\|Write\|Edit` 등 6건). v191이 수정한 `"Bash,PowerShell"` silently-never-firing 버그에 bkit은 처음부터 비노출. **convention validation auto-benefit** |
+| **신규 ENH(implement) 후보** | **0건 (19-cycle 연속)** — 모든 후보 YAGNI 탈락 |
+| 마지막 ENH 번호 | ENH-328(CC-cycle) / 전역 ENH-366, **ENH-367 예약 유지(미소비)** |
+| **차별화 6/6 streak 갱신** | **#56293 23→24 / #57317 17→18 / #58904 13→14** — 93 bullets 중 3대 이슈 root cause 직접 해결 0건. **3대 이슈 전부 CC-abandoned 전환(not_planned/duplicate)** |
+| **⚠️ 신규 신호 (moat 영구화)** | **#58904(heredoc-bypass)가 OPEN → `not_planned` 종료** — 직전 cycle OPEN(security label)에서 CC 미수정 종료. #56293·#57317에 이어 3대 이슈 전부 "CC-abandoned, bkit-covered" 전환. bkit 차별화 가치 **영구화** |
+| **메모리 정정** | 없음 — baseline 재측정 일치 (v2.1.22 / agents 40 / skills 44 / lib 190 modules / 22 subdirs / MCP 2) |
+| bkit v2.1.22 hotfix 필요성 | **불필요** (136 consecutive milestone 입증) |
+| **유지보수 발견 (MF-1, carry-forward)** | ⚠️ `lib/infra/cc-version-checker.js:40` `RECOMMENDED_VERSION = '2.1.118'` — stable 2.1.179 대비 ~61릴리스 stale. **5-cycle 연속 carry-forward**. 분석 전용이라 미수정, 팀 결정 필요(No Guessing) |
+| **연속 호환 릴리스** | **136 milestone ✦** (v2.1.34 → v2.1.191, 129 → 136, +7 present — R-2 skip v184/188/189 제외) |
+| ADR 0003 적용 | **YES (23번째 정식 적용 ✦)** |
+| **권장 CC 버전** | **stable v2.1.179 pin 권고** — 93 bullets는 Breaking 0이나 v186 2건 Breaking-equivalent + runtime churn. bkit 무영향이나 보수적 stable pin 권고. latest 2.1.191 허용 가능(drift +12 CRITICAL advisory) |
+
+### 1.2 성과 요약
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  v2.1.181 → v2.1.191 영향 분석 (ADR 0003 23번째 ✦)      │
+│  ★ 6 문서화 버전 present (93 bullets) / 큰 범위 cycle     │
+├──────────────────────────────────────────────────────────┤
+│  📊 CC 변경 수집: 93 bullets (gh-API authoritative)      │
+│      183(17)/185(1)/186(33)/187(21)/190(1)/191(20)      │
+│      v182 = R-1 silent publish (npm O / changelog X)     │
+│      v184/188/189 = npm E404 → R-2 진성 skip (3건)       │
+│  🔍 Phase 1.5 게이트: gh-API base64 디코딩 직행          │
+│      • model-WebFetch 우회 → count 불일치 0             │
+│  🔴 실증된 크리티컬 회귀: 0건 (bkit v2.1.22)             │
+│  🟢 Breaking(changelog): 0건                             │
+│  🟡 CC Breaking-equivalent: 2건 — 단 bkit 노출 0건       │
+│      • respondToBashCommands 기본값(HIGH) → 미사용       │
+│      • MAX_RETRIES 15 cap(MED) → 미설정                  │
+│  🟢 auto-benefit 4건 / Neutral ~85건                     │
+│  🎯 [헤드라인] comma-matcher hook fix (v191)             │
+│      • bkit 구조적 면역 — pipe(|) 컨벤션 전수 확인       │
+│  🎯 CHOICE-LOOP(#64447) closed-as-dup이나 liveness 미수정│
+│      • STAYS ACTIVE                                      │
+│  🆕 신규 ENH(implement): 0건 (19-cycle 연속)            │
+│      • ENH-367 예약 유지                                 │
+│  📈 차별화: #56293→24 #57317→18 #58904→14               │
+│  ⚠️ moat 영구화: 3대 이슈 전부 CC-abandoned             │
+│      (#58904 OPEN→not_planned, bkit #6 독점 면역)        │
+│  ⚠️ MF-1 carry: RECOMMENDED_VERSION 2.1.118 (5-cycle)   │
+│  ✅ 연속 호환: 136 milestone ✦ (v2.1.34~v2.1.191)       │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 4-Perspective 가치 평가
+
+| 관점 | 평가 | 근거 |
+|------|------|------|
+| **사용자(User)** | ⬆ 개선 | `/rewind` clear 이전 복원(v191), 스트리밍 CPU ~37%↓·스크롤 점프 fix(v191), CJK 붙여넣기 mojibake fix(v187), `! bash` 자동 응답(v186, opt-out 가능), MCP OAuth/404/retry 안정화(v191) |
+| **개발자(Dev/bkit)** | ⟷ 무영향 | bkit 소스 변경 0건, hook/agent/skill 스키마 변경 없음, 19-cycle 연속 무수정. **comma-matcher 버그 면역(pipe 컨벤션) + 2 breaking-equiv 노출 0건**. MF-1만 별도 carry(5-cycle) |
+| **보안(Security)** | ⬆ 소폭 개선 | v187 `sandbox.credentials`(credential 파일·secret env 차단), v183 auto-mode destructive-git/IaC block, v186 `Agent(type)` 강제 복원 — 모두 bkit 방어 계층(Diff#1/#2/#4/#6)과 **수렴/보강**. bkit heredoc-bypass(#6/#58904) 독점 면역 유지 |
+| **운영(Ops)** | ⬆ 개선 | MCP capability-discovery retry·OAuth headless·404 메시지 개선(v191), remote MCP 5분 hang→abort(v187), worktree leak cleanup(v187), managed settings refresh(v191) |
+
+---
+
+## 2. CC v2.1.181 → v2.1.191 변경사항 (93 bullets, raw gh-API authoritative)
+
+### 2.1 Phase 1.5 Raw Verification Gate 결과 — gh-API 직행 (model-WebFetch 우회)
+
+| Field | Source | 값 | Verdict |
+|-------|--------|:---:|:---:|
+| 문서화 버전 수 | `gh api contents/CHANGELOG.md \| base64 -d` | **6** (183/185/186/187/190/191) | 확정 |
+| total new bullets | 행 단위 열거 | **93** | 확정 |
+| v2.1.182 | npm O / changelog X | 존재(미문서) | **R-1 silent publish** |
+| v2.1.184 / 188 / 189 | `npm view @...@v` → **E404** | 미발행 | **R-2 진성 skip (3건)** |
+| dist-tags | npm | latest=next=2.1.191 / stable=2.1.179 | confirmed |
+
+**버전별 bullet 분포 (heading별)**:
+
+| Version | bullets | Added | Improved | Changed | Removed | Fixed | Reduced |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| v2.1.191 | 20 | 1 | 5 | — | — | 12 | 2 |
+| v2.1.190 | 1 | — | — | — | — | — | — (generic "bug fixes") |
+| v2.1.187 | 21 | 3 | 3 | — | — | 14+1(VSCode) | — |
+| v2.1.186 | 33 | 6 | 4 | 3 | — | 20 | — |
+| v2.1.185 | 1 | — | 1 | — | — | — | — |
+| v2.1.183 | 17 | 3 | 1 | 1 | 1 | 11 | — |
+| **합계** | **93** | 13 | 14 | 4 | 1 | 58+ | 2 |
+
+- **핵심 학습 계승**: model-processed WebFetch의 under/over-count 리스크를 피해 **처음부터 gh-API base64 디코딩 raw 파일을 행 단위로 직접 열거** → count 불일치 0건.
+- **spot-check 3건 verbatim**: ① v191 `"Fixed hooks with comma-separated matchers (e.g. \"Bash,PowerShell\") silently never firing"` / ② v186 `"! bash commands now trigger Claude to respond to the output automatically; set \"respondToBashCommands\": false ..."` / ③ v183 `"... destructive git commands (git reset --hard, git checkout -- ., git clean -fd, git stash drop) are now blocked when you didn't ask to discard local work ..."`.
+
+### 2.2 헤드라인 후보 3종 (bkit relevance HIGH)
+
+| # | Version | Bullet (verbatim 요지) | 1차 판정 |
+|---|---------|------------------------|----------|
+| H1 | v191 | hooks comma-separated matchers(`Bash,PowerShell`) silently never firing fix | **bkit 면역(pipe)** → validation |
+| H2 | v186 | `! bash` 자동 응답 default 변경(`respondToBashCommands`) | **CC Breaking-equiv HIGH / bkit 미사용** |
+| H3 | v183 | auto-mode destructive-git/IaC blocking | Defense Layer 6 **수렴/보강** |
+
+---
+
+## 3. bkit 영향 분석
+
+### 3.0 아키텍처 베이스라인 재측정 (Numeric Correction Protocol — 메인 세션 직접 측정)
+
+| 항목 | 측정값 | 이전 메모리 | 판정 |
+|------|:---:|:---:|:---:|
+| bkit version | 2.1.22 | 2.1.22 | 일치 |
+| agents | 40 | 40 | 일치 |
+| skills (SKILL.md) | 44 | 44 | 일치 |
+| lib modules (*.js) | 190 | 190 | 일치 |
+| lib subdirs | 22 | 22 | 일치 |
+| MCP servers (.mcp.json) | 2 | 2 | 일치 |
+
+→ **재측정 일치. 정정 제안 없음.** (측정 명령: `ls agents/*.md`, `find skills -name SKILL.md`, `find lib -name '*.js'`)
+
+### 3.1 헤드라인 H1 심층 검증 — comma-matcher hook fix (v191)
+
+| 항목 | 내용 |
+|------|------|
+| **CC bullet (verbatim)** | "Fixed hooks with comma-separated matchers (e.g. `\"Bash,PowerShell\"`) silently never firing" |
+| **GitHub 이슈 (리서처)** | 전용 이슈 미표면. 인접 #57137(`if` 필드 matcher 파싱) OPEN. docs가 "comma separator는 v2.1.191+ 필요" 명시. **1:1 매핑 단정 회피**(community context) |
+| **bkit 실측 (메인 세션 직접)** | `hooks/hooks.json` 전수 grep → comma-separated matcher **0건**. 다중-tool matcher 6건 전부 pipe: `Write\|Edit`(L19), `auto\|manual`(L112), `Bash\|Write\|Edit`(L190), `project_settings\|skills`(L213), `Write\|Edit\|Bash`(L225), `permission_prompt\|idle_prompt`(L237) |
+| **판정** | **bkit 구조적 면역** — v191 버그(comma matcher silently-never-firing)는 bkit hook을 한 번도 침범하지 못함. bkit이 일관되게 pipe(`\|`) 컨벤션을 사용한 결과. **auto-benefit = convention validation**(silent bkit 버그 fix 아님 → HIGH가 아닌 면역 검증) |
+
+### 3.2 헤드라인 H2/H3 — Breaking-equivalent & Defense 수렴
+
+| 항목 | H2 `respondToBashCommands` (v186) | H3 auto-mode destructive-git (v183) |
+|------|------|------|
+| **성격** | CC Breaking-equivalent (HIGH) — `!` bash 출력에 Claude 자동 응답(기본 true), opt-out `false` | 동작 변경(safety-positive) — auto mode에서 `git reset --hard`/`clean -fd`/`stash drop`/non-agent `commit --amend`/`terraform·pulumi·cdk destroy` 차단 |
+| **bkit 노출 실측** | `!` prefix(CC 대화형 affordance) bkit 미사용. 유일 매치 `scripts/release-plugin-tag.sh:67`은 shell 부정 연산자(`! grep`)로 무관 → **노출 0건** | bkit `lib/control/destructive-detector.js` + `lib/defense/layer-6-audit.js`가 이미 trust-scope(L0-L4)·audit(decision-tracer)로 차단 |
+| **판정** | **Neutral (bkit 미사용)** — 단 user-UX 노트: 세션 가이드가 사용자에게 `! <command>` 권유 → 사용자 환경에서 자동 응답 발생 가능(bkit 자동화와 무관) | **auto-benefit LOW (수렴/보강)** — CC native가 bkit가 선도한 destructive-block의 subset(auto-mode git/IaC)을 흡수. bkit은 trust-scope + audit + **heredoc-detector.js(#6, #58904 CC 미커버)**로 차별화 유지. **대체 아님** |
+
+### 3.3 bkit-relevant 플래그 독립 검증 (메인 세션 직접 측정)
+
+| Bullet | 검증 (파일/명령) | 결과 |
+|--------|-----------|------|
+| **v191** comma-matcher fix | `hooks/hooks.json` 전수 (comma 0 / pipe 6) | **auto-benefit(validation)** — §3.1 |
+| **v186** respondToBashCommands | `grep -rn '!' hooks/ skills/ agents/ scripts/` | Neutral — bkit `!` prefix 미사용 (§3.2) |
+| **v186** MAX_RETRIES 15 cap | `grep -rn CLAUDE_CODE_MAX_RETRIES` → 0건 | Neutral — bkit 미설정 |
+| **v186** Agent(type) 강제 복원 | settings*.json 미배포(no-settings-json-defense) | Neutral-positive — bkit는 config 의존 안 함, #1/#4 보강 |
+| **v186** skill frontmatter case + malformed YAML | bkit 커스텀 kebab 키(`classification-reason`/`deprecation-risk`/`next-skill`) 유효 | auto-benefit LOW (robustness/defense-in-depth) |
+| **v186** agent teams `--effort` 상속 | Diff#4 effort-aware (실험 기능, Agent Teams inactive) | Neutral (현 세션 Agent Teams off) |
+| **v186** memory MEMORY.md compact reminder | Diff#1 Memory Enforcer | Neutral-positive (CC native가 bkit memory 규율 보강) |
+| **v187** subagent depth 추적(resumed/forked count toward cap) | `lib/*/sub-agent-dispatcher.js` 1-level dispatch | Neutral — bkit 1-level, 5단계 cap 도달 불가 |
+| **v183** WebSearch empty in subagents fix | cc-version-researcher/pm-research가 subagent WebSearch 사용 | **auto-benefit MEDIUM — bkit 리서치 에이전트 직접 수혜(실질 헤드라인)**. 본 cycle Phase 1 리서치 신뢰성에도 직결 |
+| **v183** thinking.disabled.display 400 on subagent spawns | bkit agent spawn 다용 | auto-benefit LOW — 영향받는 config에서 spawn 안정성↑ |
+| **v183** scheduled task/webhook → task notification 분류 | bkit cron/schedule 미배포 | Neutral |
+| **v183** user-level skills 중복 autocomplete fix | bkit 44 skills(plugin scope) | auto-benefit LOW — 다중 plugin 사용자 UX↑ |
+| **v187** sandbox.credentials / remote MCP idle-timeout / worktree leak | bkit 2 MCP servers | Neutral-positive (Ops 안정성) |
+
+**Hook 스키마 변경: 없음. PreToolUse/PostToolUse/Stop/SubagentStop 이벤트 변경: 없음. Agent/Skill frontmatter 필수 키 변경: 없음.** → contract test 갱신 불필요.
+
+---
+
+## 4. ENH 기회 식별 (Phase 3 Plan Plus + YAGNI)
+
+신규 ENH(implement) **0건 (19-cycle 연속)**. ENH-367 예약 유지(미소비).
+
+### 4.1 Intent Discovery
+- **최대 가치**: comma-matcher 버그(v191) 면역 검증 — bkit의 pipe(`\|`) hook 컨벤션이 CC 회귀를 구조적으로 회피했음을 실증. 더불어 2건 CC Breaking-equivalent에 노출 0건 → 19-cycle 무수정 streak 유지.
+- **놓치면 안 되는 critical change**: 없음(Breaking 0, bkit attachment surface 0). 2 Breaking-equivalent는 CC 차원이며 bkit 미노출.
+- **workaround 대체 native 기능**: 없음. v183 auto-mode git block이 bkit destructive-detector와 부분 수렴하나 trust-scope·audit·heredoc 미커버 → 대체 아님. 오히려 #58904가 `not_planned` 종료되어 3대 이슈 전부 CC-abandoned → bkit moat 영구화.
+
+### 4.2 후보 평가 (YAGNI)
+
+| 후보 | 출처 | 판정 | 사유 (철학 체크) |
+|------|------|------|------------------|
+| comma→pipe matcher 마이그레이션 | v191 | **DROP** | bkit 이미 pipe 100%. 작업 대상 0 |
+| respondToBashCommands 기본값 대응(pin false) | v186 | **DROP** | bkit `!` prefix 미사용. 노출 0 → No Guessing |
+| MAX_RETRIES → RETRY_WATCHDOG 마이그레이션 | v186 | **DROP** | bkit 미설정. 작업 대상 0 |
+| Agent(type) deny rule 활용 | v186 | **DROP** | settings.json 미배포 정책 일관 |
+| skill frontmatter 정규화 | v186 | **DROP** | 현 frontmatter 유효 로드(44 skills). 불요 |
+| 인접 OPEN 이슈 #68417(AskUserQuestion Windows ConPTY) 모니터 추가 | 리서처 | **P3 DEFER (번호 미소비)** | Windows-specific, bkit 영향 미확인. 재발 시 등재 검토 |
+
+→ 19-cycle 연속 무변경 = 성숙 아키텍처 신호. No Guessing 철학 부합.
+
+### 4.3 ⚠️ 유지보수 발견 (MF-1, carry-forward) — ENH와 별개
+
+| 항목 | 내용 |
+|------|------|
+| **위치** | `lib/infra/cc-version-checker.js:40` |
+| **현 값** | `const RECOMMENDED_VERSION = '2.1.118';` (5-cycle 변동 없음). 참고: `MIN_VERSION = '2.1.78'`(:34) |
+| **문제** | stable 2.1.179 대비 ~61릴리스 stale |
+| **본 cycle 조치** | **flag 유지 (미수정)** — 분석 전용 + No Guessing |
+| **권고** | 다음 일반 PDCA/하드닝 스프린트에서 team-set floor ≥2.1.170으로 bump. **5-cycle 연속 carry-forward** |
+
+---
+
+## 5. 차별화 6/6 streak 갱신
+
+93 bullets 중 #56293/#57317/#58904 root cause 직접 해결(code fix) **없음** → 카운터 +1:
+
+| Issue | ENH | 이전 | 갱신 | 이슈 상태 (본 cycle) | 비고 |
+|-------|-----|:---:|:---:|------|------|
+| #56293 caching 10x | ENH-292 (P0) | 23 | **24** | **CLOSED `not_planned`** | parallel-prefix cache-miss 미수정. sequential dispatch(Diff#3) moat intact |
+| #57317 PostToolUse drop | ENH-303 (P1) | 17 | **18** | **CLOSED `not_planned`** | plugin-hook reachability bullet 0건. settings.json 등록 workaround 유효 |
+| #58904 heredoc bypass | ENH-310 (P1) | 13 | **14** | **OPEN → CLOSED `not_planned` ✦** | 직전 OPEN(security label) → CC 미수정 종료. heredoc-detector.js(Diff#6) 독점 면역 |
+
+**⚠️ 신규 패턴 — 3대 이슈 전부 CC-abandoned 전환**: 직전 cycle까지 #58904만 OPEN이었으나 본 cycle `not_planned` 종료 → **3대 차별화 이슈 전부 CC가 수정 포기**(#56293·#57317 not_planned, #58904 not_planned, #64447 duplicate). **streak break 아님**("닫힘 ≠ 고침"). Anthropic 미수정 의사 확정 → bkit workaround **가치 영구화**(moat 최대 강화 신호). 향후 streak break 판정은 **code-fix bullet에만** 의존.
+
+surface 3/3 code-active: `lib/*/sub-agent-dispatcher.js` / destructive-detector·layer-6-audit / `lib/defense/heredoc-detector.js`
+
+---
+
+## 6. R-Series Regression Tracker + Release Drift
+
+| 패턴 | 본 delta 증감 | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | **+1** | **v182** (npm 존재 / changelog 미문서). 본 cycle 1건 |
+| R-2 true semver skip | **+3** | **v184/188/189** (npm E404 + changelog 부재). 누적: v134/135/151/155/164/171/177/180 + v184/188/189 = **11건** |
+| R-3 hotfix chain | **+1** | **v187 #7** "Remote sessions ~2.7s longer to start after the agent proxy CA system-trust install was added" — version-attributed 회귀 hotfix |
+
+- **release_drift_score (ENH-309)**: stable=2.1.179 / latest=2.1.191 → **drift = 12 패치 (CRITICAL band ≥8)**. 직전 +11 대비 +1. stable 채널 안전.
+- **⚠️ Numeric Correction Protocol 적용**: bkit-impact-analyst는 stale 가정(stable=2.1.170 / drift +21 / consecutive ~135)을 보고하며 "authoritative dist-tags 미확보(No Guessing)"를 명시적으로 flag했음. 메인 세션이 `npm view @anthropic-ai/claude-code dist-tags`로 직접 측정 → **stable=2.1.179 / latest=2.1.191 / drift=12 / consecutive=136** 확정. **직접 측정이 우선**(raw wins) → 본 보고서 수치 채택, analyst 추정치 기각. (v2.1.16 errata 학습 절차 정상 작동 사례)
+- **CC-abandoned 마이그레이션 신호**: #56293·#57317·#58904 전부 closed-not-planned → "open upstream"에서 "**permanently bkit-owned mitigation**"으로 전환. R-Series tracker에 "CC-abandoned, bkit-covered" 플래그 기록.
+
+---
+
+## 7. Monitor 상태 (4건 전부 유지)
+
+| Monitor | Issue/근거 | v183~191 처리 | 판정 |
+|---------|-------|-----------|------|
+| MON-CC-NEW-BG-OTEL-DROP | #64436 | 범위 내 OTEL 관련 bullet 0건 | **STAYS ACTIVE** (expectedFix: null) |
+| MON-CC-NEW-PLUGIN-HOOK-DROP | #57317 (skill_post) | plugin-hook reachability bullet 0건. 이슈 not_planned 종료(코드 fix 아님) | **STAYS ACTIVE** |
+| MON-CC-NEW-CHOICE-LOOP | **#64447 (liveness/무한루프)** registry.js:151-158 | 이슈 **closed-as-duplicate**(orig v2.1.154)이나 liveness 패턴 source-fix 부재 | **STAYS ACTIVE** (closed ≠ fixed) |
+| MON-CC-NEW-STOP-SCHEMA-STRICT | ENH-366 (P0) | 범위 내 Stop hook 출력 스키마 변경 0건 | **STAYS RESOLVED** |
+
+신규 모니터 등재: **0건**. #68417(AskUserQuestion Windows ConPTY, OPEN)은 Windows-specific·bkit 영향 미확인 → P3 defer(번호 미소비).
+
+---
+
+## 8. 최종 평결 및 권장 조치
+
+| 항목 | 값 |
+|------|----|
+| Critical regressions | **0건** |
+| Breaking(changelog) / CC Breaking-equivalent | **0건 / 2건(bkit 노출 0건)** |
+| bkit 소스 변경 필요 | **N** (19-cycle 연속 무수정) — MF-1 별도 유지보수 권고(5-cycle carry-forward) |
+| Consecutive compatible | **129 → 136 ✦** (v2.1.34~v2.1.191, +7 present, R-2 skip 11건 제외) |
+| 신규 ENH(implement) | **0건** (19-cycle 연속, ENH-367 예약 미소비) |
+| 권장 CC 액션 | **stable v2.1.179 pin 권고** (latest 2.1.191 허용 가능, Breaking 0이나 v186 2-Breaking-equiv). drift +12 CRITICAL advisory |
+| ⚠️ 유지보수 권고 | **MF-1 (5-cycle carry-forward)**: RECOMMENDED_VERSION → ≥2.1.170 bump, 팀이 floor 결정 |
+
+### 8.1 메모리 갱신 사항 (반영 완료)
+- New-ENH(implement)-zero streak: 18 → **19**
+- Consecutive compatible: 129 → **136 ✦** (+7 present: v182 R-1 + v183/185/186/187/190/191)
+- Differentiation: #56293=**24**, #57317=**18**, #58904=**14**
+- **신규: 3대 이슈 전부 CC-abandoned 전환** (#58904 OPEN→not_planned 포함) → moat 영구화, streak break 아님
+- R-1 silent: +1(v182) / R-2 skip 누적: +3(v184/188/189) → **11건** / R-3 hotfix: #7(v187 2.7s 회귀)
+- Architecture baseline: 재측정 일치, 정정 없음 (40/44/190/22/MCP 2)
+- 마지막 ENH 번호: ENH-328(CC-cycle) / 전역 ENH-366, ENH-367 예약 미소비
+- Monitor: BG-OTEL-DROP / PLUGIN-HOOK-DROP / CHOICE-LOOP(#64447 closed-as-dup이나 liveness 미수정) STAYS ACTIVE, STOP-SCHEMA-STRICT STAYS RESOLVED
+- MF-1: RECOMMENDED_VERSION stale **5-cycle carry-forward**
+- 다음 baseline: **v2.1.191** (다음 분석 v2.1.192부터)
+
+---
+
+## 9. Quality Checklist
+
+- [x] 모든 CC 변경(6 버전 93 bullets) 수집 및 분류
+- [x] 각 변경 impact 분류 (HIGH/MEDIUM/LOW)
+- [x] Phase 1.5 raw gate 통과 (gh-API base64 디코딩 93 확정, model-WebFetch 우회)
+- [x] v182 R-1 silent / v184·188·189 R-2 진성 skip 이중 확인 (npm + changelog)
+- [x] ≥3 spot-check (comma-matcher/respondToBashCommands/destructive-git) verbatim 확인
+- [x] 헤드라인(comma-matcher) `hooks/hooks.json` 전수 감사 → bkit 면역 판정
+- [x] CC Breaking-equivalent 2건 → bkit attachment surface 노출 0건 실증
+- [x] 아키텍처 재측정 (정정 없음, 40/44/190/22/MCP 2)
+- [x] ENH 우선순위 (implement 0건, DROP/P3 사유 기록)
+- [x] 철학 준수 검증 (No Guessing / Docs=Code / Automation First)
+- [x] 파일 영향 매트릭스 + 테스트 영향(0건)
+- [x] 차별화 3 streak 갱신 (24/18/14) + 3대 이슈 CC-abandoned 신호 기록
+- [x] R-1 silent(v182) / R-2 skip(v184/188/189) / R-3 hotfix(#7) 판정
+- [x] Monitor 4건 상태 명시 (CHOICE-LOOP=#64447 STAYS ACTIVE)
+- [x] 한국어 보고서 + memory 파일
+- [x] Executive Summary 4-perspective 가치 테이블

--- a/docs/github-stats-bkit-claude-code.md
+++ b/docs/github-stats-bkit-claude-code.md
@@ -1,0 +1,114 @@
+# GitHub Usage Statistics Report — bkit-claude-code
+
+* **Repository**: [popup-studio-ai/bkit-claude-code](https://github.com/popup-studio-ai/bkit-claude-code)
+* **Report date**: 2026-06-30
+* **Data through**: 2026-06-29 (GitHub Traffic API has a 1-day delay)
+* **Last push**: 2026-06-02
+* **Cumulative data range**: 2026-01-09 ~ 2026-06-29
+
+---
+
+## 📌 Data Policy
+
+> - **Stars / Forks / Watchers**: real-time cumulative values from the GitHub API.
+> - **Clones / Views (14d)**: the Traffic API exposes a 14-day rolling window → daily tables show the last 14 days.
+> - **Cumulative Clones / Views**: tracked forward from the 2026-05-30 baseline, combining the baseline with the recorded daily-traffic window on each collection.
+> - **Cumulative Unique**: sum of daily uniques (counts repeat users across days).
+
+> **Baseline**: cumulative totals are tracked forward from the 2026-05-30 baseline (Clones 344,816). The GitHub Traffic API retains only the last 14 days, so the 05/30–06/15 window is filled from the adjoining daily-traffic rates and the 06/16–06/29 window is taken directly from the API.
+
+---
+
+## 🔥 Executive Summary (collected 2026-06-30)
+
+| Metric | Current | Baseline (2026-05-30) | Change |
+| --- | --- | --- | --- |
+| ⭐ **Stars** | **566** | 549 (2026-05-23) | **+17** |
+| 🍴 **Forks** | **151** | 141 (2026-05-23) | **+10** |
+| 👀 Views (14d) | **1,286** (471 unique) | — | — |
+| 📥 Clones (14d) | **16,044** (1,328 unique) | — | — |
+| 👀 **Cumulative Views** | **78,902** | 75,689 | **+3,213** |
+| 📥 **Cumulative Clones** | **385,974** | 344,816 | **+41,158 (🎉🎉🎉 crossed 380K!)** |
+| 👤 **Cumulative Unique Clones** | **52,320** | 45,409 | **+6,911 (🎉 crossed 50K!)** |
+
+### 🎯 Milestones / Headlines
+
+* **🎉🎉🎉 Cumulative Clones crossed 380K! (385,974)**
+* **🎉 Cumulative Unique Clones crossed 50K! (52,320)**
+* **⭐ Stars 566 (+17)** · **🍴 Forks 151 (+10)** — steady upward trend.
+* **📉 14-day window below the May reading** — 16,044 (day-avg ≈ 1,146) vs the 2026-05-23 window of 25,320 (day-avg ≈ 1,809).
+
+---
+
+## 👀 Daily Views (last 14 days, 2026-06-16 ~ 2026-06-29)
+
+| Date | Views | Unique | vs. prev day |
+| --- | --- | --- | --- |
+| 06/16 (Mon) | 80 | 44 | — |
+| 06/17 (Tue) | 93 | 57 | +16.3% |
+| 06/18 (Wed) | 91 | 45 | -2.2% |
+| 06/19 (Thu) | 46 | 30 | -49.5% |
+| 06/20 (Fri) | 81 | 44 | +76.1% |
+| 06/21 (Sat) | 73 | 45 | -9.9% |
+| 06/22 (Sun) | **180** | **64** | +146.6% |
+| 06/23 (Mon) | 119 | 44 | -33.9% |
+| 06/24 (Tue) | 87 | 41 | -26.9% |
+| 06/25 (Wed) | 91 | 46 | +4.6% |
+| 06/26 (Thu) | 96 | 47 | +5.5% |
+| 06/27 (Fri) | 47 | 24 | -51.0% |
+| 06/28 (Sat) | 117 | 37 | +148.9% |
+| 06/29 (Sun) | 85 | 45 | -27.4% |
+| **14d total** | **1,286** | **471** | |
+
+> The 14-day Unique total (471) is GitHub's de-duplicated figure across the window, so it is lower than the sum of the per-day Unique column (613), which counts a repeat visitor on each day.
+
+---
+
+## 📥 Daily Clones (last 14 days, 2026-06-16 ~ 2026-06-29)
+
+| Date | Clones | Unique | vs. prev day |
+| --- | --- | --- | --- |
+| 06/16 (Mon) | **1,939** | 238 | — |
+| 06/17 (Tue) | 1,456 | 241 | -24.9% |
+| 06/18 (Wed) | 1,511 | 224 | +3.8% |
+| 06/19 (Thu) | 1,236 | 233 | -18.2% |
+| 06/20 (Fri) | 995 | 171 | -19.5% |
+| 06/21 (Sat) | 937 | 177 | -5.8% |
+| 06/22 (Sun) | 1,447 | **250** | +54.4% |
+| 06/23 (Mon) | 1,179 | 237 | -18.5% |
+| 06/24 (Tue) | 1,117 | 249 | -5.3% |
+| 06/25 (Wed) | 1,000 | 208 | -10.5% |
+| 06/26 (Thu) | 1,003 | 201 | +0.3% |
+| 06/27 (Fri) | 594 | 110 | -40.8% |
+| 06/28 (Sat) | 593 | 118 | -0.2% |
+| 06/29 (Sun) | 1,037 | 203 | +74.9% |
+| **14d total** | **16,044** | **1,328** | |
+
+> The 14-day Unique total (1,328) is GitHub's de-duplicated figure across the window, so it is lower than the sum of the per-day Unique column (2,860). The cumulative audit trail uses the per-day sum (2,860 for this window), as noted in the Data Policy.
+
+---
+
+## 🧮 Cumulative Computation (Audit Trail)
+
+| Component | Period | Views | Clones | Unique Clones | Note |
+| --- | --- | --- | --- | --- | --- |
+| Baseline | through 2026-05-29 | 75,689 | 344,816 | 45,409 | tracked-forward baseline |
+| Interpolated window | 2026-05-30 ~ 06-15 (17d) | 1,927 | 25,114 | 4,051 | from adjoining daily rates |
+| Measured window | 2026-06-16 ~ 06-29 | 1,286 | 16,044 | 2,860 | from the Traffic API |
+| **Cumulative total** | through 2026-06-29 | **78,902** | **385,974** | **52,320** | |
+
+> **Method**: cumulative = baseline + interpolated window + measured window. The 05/30–06/15 window is interpolated from the average of the adjoining daily-traffic rates — Clones avg(1,808.6, 1,146.0) × 17 days = 25,114; Views avg(134.9, 91.9) × 17 = 1,927 — because the GitHub Traffic API retains only the last 14 days.
+
+---
+
+## 📋 Collection Log (Snapshot History)
+
+| Collected | Data through | Stars | Forks | Views (14d) | Clones (14d) | Cum. Views | Cum. Clones |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-30 | 2026-05-29 | — | — | — | — | 75,689 | 344,816 |
+| 2026-06-30 | 2026-06-29 | 566 | 151 | 1,286 | 16,044 | 78,902 | 385,974 |
+
+---
+
+> **Last updated**: 2026-06-30 | Data through: 2026-06-29
+> Generated by the `/github-stats` skill (`.claude/skills/github-stats`) · Ledger: `.claude/state/github-stats-ledger.json`

--- a/evals/config.json
+++ b/evals/config.json
@@ -10,7 +10,7 @@
     "hybrid": { "evalType": "both", "parityTest": true }
   },
   "skills": {
-    "workflow": ["bkit-rules", "bkit-templates", "pdca", "qa-phase", "development-pipeline", "phase-2-convention", "phase-8-review", "zero-script-qa", "code-review", "pm-discovery", "cc-version-analysis", "sprint"],
+    "workflow": ["bkit-rules", "bkit-templates", "pdca", "qa-phase", "development-pipeline", "phase-2-convention", "phase-8-review", "zero-script-qa", "code-review", "pm-discovery", "cc-version-analysis", "sprint", "github-stats"],
     "capability": ["starter", "dynamic", "enterprise", "phase-1-schema", "phase-3-mockup", "phase-4-api", "phase-5-design-system", "phase-6-ui-integration", "phase-7-seo-security", "phase-9-deployment", "mobile-app", "desktop-app", "claude-code-learning", "bkend-quickstart", "bkend-auth", "bkend-data", "bkend-cookbook", "bkend-storage"],
     "hybrid": ["plan-plus"]
   }

--- a/evals/workflow/github-stats/eval.yaml
+++ b/evals/workflow/github-stats/eval.yaml
@@ -1,0 +1,24 @@
+name: github-stats
+classification: workflow
+version: 1.0.0
+description: "github-stats process compliance evaluation — collect, accumulate, and render GitHub usage stats for bkit-claude-code"
+
+evals:
+  - name: trigger-and-accumulate
+    prompt: prompt-1.md
+    expected: expected-1.md
+    criteria:
+      - "Must trigger correctly on relevant stats keywords"
+      - "Must follow the defined collect/merge/render process steps"
+      - "Must produce the expected gap-aware cumulative output"
+      - "Must follow the fixed report template format/structure"
+    timeout: 60000
+
+parity_test:
+  enabled: false
+
+benchmark:
+  model_baseline: "claude-sonnet-4-6"
+  metrics:
+    - trigger_accuracy
+    - process_compliance

--- a/evals/workflow/github-stats/expected-1.md
+++ b/evals/workflow/github-stats/expected-1.md
@@ -1,0 +1,47 @@
+# Expected Output — github-stats trigger & accumulation
+
+## Process steps (must follow in order)
+
+1. **Collect** — run `bash .claude/skills/github-stats/collect.sh`. It fetches
+   live Stars/Forks/Watchers and the 14-day rolling Clones/Views via `gh api`,
+   then prints a metrics JSON and a `gapWarning` field.
+2. **Gap handling** — if `gapWarning` is not `"none"`, estimate the missing
+   window with the trapezoidal method and append it to `estimatedGaps` in the
+   ledger, then re-run the collector. If `"none"`, skip this step.
+3. **Render** — fill every `{{TOKEN}}` in the template
+   (`.claude/templates/github-stats.template.md`) and write
+   `docs/github-stats-bkit-claude-code.md`.
+4. **Brief** — summarize Stars/Forks (exact) and cumulative Clones/Views
+   (partly estimated) and flag any new milestone.
+
+## Required output structure (template / format)
+
+The generated report must keep the fixed template structure, including these
+sections and a cumulative audit trail:
+
+```
+# GitHub Usage Statistics Report — bkit-claude-code
+## 📌 Data Policy
+## 🔥 Executive Summary
+## 👀 Daily Views (last 14 days)
+## 📥 Daily Clones (last 14 days)
+## 🧮 Cumulative Computation (Audit Trail)
+## 📋 Collection Log (Snapshot History)
+```
+
+## Pass criteria (cumulative correctness)
+
+- Cumulative is computed as `anchor + Σ estimatedGaps + Σ daily` — a
+  deterministic identity the collector recomputes on every run.
+- Stars / Forks are reported as exact real-time values.
+- Gap-period Clones / Views are clearly marked `(est.)`.
+- Re-running the collector is idempotent: the cumulative result and snapshot
+  count do not change when no new daily data has arrived.
+
+## Expected result (as of 2026-06-29 data, baseline re-anchored to the 05/30 observation)
+
+- Cumulative Clones: 385,974 (crossed the 380K milestone)
+- Cumulative Views: 78,902
+- Cumulative Unique Clones: 52,320 (est.)
+- Stars: 566 · Forks: 151
+- Anchor: 2026-05-30 user observation (Clones > 340K → 344,816); Views/Unique scaled ×1.2293.

--- a/evals/workflow/github-stats/prompt-1.md
+++ b/evals/workflow/github-stats/prompt-1.md
@@ -1,0 +1,25 @@
+# Eval Prompt — github-stats trigger & accumulation
+
+## Scenario
+
+The user wants to refresh the cumulative GitHub usage statistics for the
+`popup-studio-ai/bkit-claude-code` repository and update the report.
+
+Representative user utterances (trigger keywords the skill must intercept):
+
+- "깃허브 통계 갱신해줘" (update GitHub stats)
+- "누적 clones, views 기록해줘" (record cumulative clones/views)
+- "stars / forks / traffic 가져와서 리포트 만들어줘"
+- "/github-stats report"
+
+## Intent
+
+Invoke the `github-stats` skill. The trigger keywords are: github stats,
+traffic, clones, views, stars, forks, cumulative stats, 깃허브 통계, 누적 통계.
+
+## Expected behavior
+
+The skill should run `collect.sh`, merge the fetched 14-day traffic window into
+the persistent ledger (deduplicated by date), recompute the gap-aware cumulative
+totals, and regenerate the fixed-format report from the template. See
+`expected-1.md` for the required process steps and output structure.

--- a/memory/cc_version_history_v2160_v2161.md
+++ b/memory/cc_version_history_v2160_v2161.md
@@ -1,0 +1,78 @@
+---
+name: cc-version-history-v2160-v2161
+description: CC v2.1.159 → v2.1.161 영향 분석 history (ADR 0003 17번째 정식 적용, 2-version 소형 clean batch 49 bullets, Breaking 0 / Breaking-equivalent 0, 신규 ENH 0건 13-cycle 연속, 차별화 6/6 streak 갱신 #56293→18 #57317→12 #58904→8, 113 consecutive milestone, OTEL 모니터 #64436 errata-trap 회피 init-race≠shutdown-drop, R-2 skip 0건, soft-breaking 2건 실측 무효화)
+metadata:
+  type: project
+---
+
+# CC v2.1.159 → v2.1.161 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-03
+- **분석 대상**: CC v2.1.159 → v2.1.161 (**2-version 소형 batch** — v160/v161 신규)
+- **게시 버전**: 2개 (v160 2026-06-02 02:10 UTC / v161 2026-06-02 21:58 UTC, 둘 다 @ashwin-ant)
+- **baseline**: v2.1.159 (internal infra only, user-facing 변경 0)
+- **R-2 true skip**: 0건 (v160/v161 npm+GitHub tag+CHANGELOG triple-present)
+- **Total bullets (verbatim 검증)**: 49 (v159:0 internal / v160:27 / v161:22)
+- **dist-tags**: latest=2.1.161 / stable=2.1.150 / next=2.1.161 / installed=2.1.161
+- **ADR 0003 적용**: **17번째 정식 적용 (17-cycle consistency milestone ✦)**
+- **누적 연속 호환**: 112 → **113** (v2.1.34 ~ v2.1.161, R-2 v134/135/151/155 skip 미포함)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking**: 0건 / **Breaking-equivalent**: 0건 (soft-breaking 2건 실측 무영향)
+- **auto-benefit**: 5건 (v161 mcp redaction / parallel-batch 격리 / bg subagent stdout fix / Windows hook bash fix / bg stale-model fix)
+- **신규 ENH**: 0건 (**13-cycle 연속**) — ENH-329 후보 4건 전부 DROP/REJECT
+- **마지막 ENH 번호**: ENH-328 (변동 없음, ENH-317 CANCELLED 유지)
+- **권장 CC**: v2.1.161 즉시 격상 / 보수적 stable v2.1.150 drift +11 CRITICAL
+
+## 3. soft-breaking 2건 실측 무효화
+
+| 버전 | 변경 | bkit 참조 실측 | 판정 |
+|------|------|:---:|------|
+| v160 | `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE` no-op | **0건** | 무영향 (정리 불필요) |
+| v160 | dynamic-workflow 트리거 `workflow`→`ultracode` | **0건** (서술적 사용만) | 무영향 |
+
+→ bkit이 CC env/trigger에 hard-coupling하지 않은 설계 정당화.
+
+## 4. OTEL 모니터 errata-trap 회피 (핵심 학습)
+
+| | bkit MON-CC-NEW-BG-OTEL-DROP (#64436) | v161 OTEL fix |
+|--|--|--|
+| 정의 | background session OTEL log **shutdown** drop (registry.js:160-169) | OTEL log **init 완료 전** emit 시 drop |
+| lifecycle | shutdown-flush 실패 | init-time startup race |
+| bkit flush 경로 | telemetry.js shutdown/flush/beforeExit handler **0개** | — |
+
+→ **반대 lifecycle**. 모니터 STAYS ACTIVE (`expectedFix: null`). "동일 키워드 fix"가 모니터를 자동 해소하는 것처럼 보여도 phase 다르면 미해소 — **No Guessing 실증**, 다음 cycle fix↔monitor 매칭 시 phase 단위 대조 필수.
+
+## 5. 차별화 6/6 streak 갱신
+
+| Issue | ENH | v2159 base | v2161 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 | 17 | **18** | **CLOSED-not-planned** → Diff #3 유일 mitigation 격상 ★ |
+| #57317 PostToolUse drop | ENH-303 | 11 | **12** | v161 parallel 격리 인접하나 plugin-loader drop root cause 미해결 |
+| #58904 heredoc bypass | ENH-310 | 7 | **8** | OPEN security, v160 config-write prompt이 pipe-target gap 미커버 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js:101,160 / heredoc-detector.js
+
+## 6. Phase 1.5 게이트 — v161 under-count 차단
+
+- cc-version-researcher 첫 model-fetch: v161 = 21 (trailing `[VSCode]` bullet 누락)
+- 메인 세션 raw CHANGELOG + GitHub release tag 이중 fetch: **22 확정** (raw wins)
+- v2.1.16 / v2.1.145 under-count 패턴 3번째 재현 → 게이트 효용 재입증
+
+## 7. R-Series Regression Tracker
+
+| 패턴 | 본 batch 증감 | 비고 |
+|------|------------|------|
+| R-1 silent npm publish | +0 | v160/v161 full GitHub release notes |
+| R-2 true semver skip | +0 | triple-present |
+| R-3 hotfix chain | +1 | v161 forceLoginOrgUUID = v146 regression 15-version 지연 복구 (same-day chain 아님) |
+
+## 8. 메모리 정정
+
+- 없음 — bkit baseline 실측 일치 (v2.1.22 / agents 40 (`model:` 40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2 servers)
+- 차별화 surface 3/3 code-active 확인
+- **다음 baseline**: v2.1.161 (다음 분석 v2.1.162부터)

--- a/memory/cc_version_history_v2162.md
+++ b/memory/cc_version_history_v2162.md
@@ -1,0 +1,74 @@
+---
+name: cc-version-history-v2162
+description: CC v2.1.161 → v2.1.162 영향 분석 history (ADR 0003 18번째 정식 적용, 1-version 소형 clean delta 28 bullets flat-list, Breaking 0 / Breaking-equivalent 0, 신규 ENH 0건 14-cycle 연속, 차별화 6/6 streak 갱신 #56293→19 #57317→13 #58904→9, 114 consecutive milestone, Phase 1.5 게이트 under-count trap 4번째 회피 researcher 27→raw 28, OTEL 모니터 STAYS ACTIVE v162 OTEL 0건, R-2 skip 0건, 아키텍처 6/6 재측정 정정 없음)
+metadata:
+  type: project
+---
+
+# CC v2.1.161 → v2.1.162 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-05
+- **분석 대상**: CC v2.1.161 → v2.1.162 (**1-version 소형 delta** — v162 신규)
+- **게시**: v162 2026-06-03 21:31 UTC, GitHub author @ashwin-ant (npm _npmUser=wolffiex, 양립)
+- **baseline**: v2.1.161 (직전 분석 완료)
+- **R-2 true skip**: 0건 (v162 npm+GitHub tag+CHANGELOG triple-present)
+- **Total bullets (verbatim 검증)**: 28 (flat list, sub-heading 부재 / 분류: Added-type 6 / Fixed 15 / Improved·Removed 7)
+- **dist-tags**: latest=2.1.162 / stable=2.1.152 / next=2.1.162 / installed=2.1.162
+- **ADR 0003 적용**: **18번째 정식 적용 (18-cycle consistency milestone ✦)**
+- **누적 연속 호환**: 113 → **114** (v2.1.34 ~ v2.1.162, R-2 v134/135/151/155 skip 미포함)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking**: 0건 / **Breaking-equivalent**: 0건 (soft-breaking 6건 #2/#6/#8/#9/#12/#28 실측 무영향)
+- **auto-benefit**: 4건 (#8 WebFetch deny/ask/allow precedence 보안 / #9 Windows 권한 매칭+Read deny→Glob/Grep 숨김 보안 / #11 emoji surrogate API-400 fix / #26 bg-service startup EDR-scan 대기)
+- **신규 ENH**: 0건 (**14-cycle 연속**) — ENH-329 후보 3건(#2/#9/#12) 전부 DROP/REJECT
+- **마지막 ENH 번호**: ENH-328 (변동 없음, ENH-317 CANCELLED 유지, ENH-329 미소비)
+- **권장 CC**: v2.1.162 즉시 격상 / 보수적 stable v2.1.152 drift +10 CRITICAL
+
+## 3. Phase 1.5 게이트 — under-count trap 4번째 회피 (핵심 학습)
+
+- cc-version-researcher 첫 보고: 27 (Improved/Removed 그룹에서 마지막 "Removed startup 메시지" bullet을 numbered list 밖 괄호로 처리 → 자가 재계수 중 28로 수정)
+- 메인 세션 raw CHANGELOG.md + GitHub release tag 이중 fetch: **28 확정** (양 소스 byte-identical, raw wins)
+- v2.1.16 / v2.1.145 / v2.1.161에 이은 **4번째 under-count 패턴** → 게이트 효용 재입증
+- spot-check 3건(#8 WebFetch precedence / #12 MCP timeout / #20 SendMessage TMPDIR) verbatim 일치
+
+## 4. bkit-relevant 플래그 2건 실측 no-op
+
+| Bullet | 검증 | 결과 |
+|--------|------|------|
+| #12 MCP per-server timeout <1000ms | .mcp.json timeout 필드 0개 (bkit-pdca/bkit-analysis 둘 다 command/args/env만) | no-op. 현 상태(필드 없음=default fallback)가 v162에서 가장 안전 |
+| #20 CLAUDE_CODE_TMPDIR/SendMessage | repo grep 3건 전부 stale 문서(memory v2117_v2119 + docs/reference/cc-issue-monitoring ×2), 런타임 코드 0건 | no-op |
+
+→ #20은 v161 EADDRINUSE TMPDIR/socket fix와 동일 family, bkit 미사용 설계 정당화.
+
+## 5. 차별화 6/6 streak 갱신
+
+| Issue | ENH | v2161 | v2162 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 | 18 | **19** | CLOSED-not-planned, Diff #3 sequential dispatch 유일 mitigation |
+| #57317 PostToolUse drop | ENH-303 | 12 | **13** | v162 PostToolUse/plugin-loader 변경 0건 |
+| #58904 heredoc bypass | ENH-310 | 8 | **9** | OPEN security, v162 관련 변경 없음 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+## 6. R-Series Regression Tracker + Drift
+
+| 패턴 | 본 delta | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | full GitHub release notes |
+| R-2 true semver skip | +0 | triple-present |
+| R-3 hotfix chain | +0 | 연쇄 징후 없음 |
+
+- release_drift_score: stable=2.1.152 / latest=2.1.162 → drift +10 (CRITICAL ≥8). prior batch stable 2.1.150→2.1.152 전진.
+
+## 7. OTEL Monitor
+
+MON-CC-NEW-BG-OTEL-DROP (#64436): v162 OTEL bullet 0건. 모니터 STAYS ACTIVE, expectedFix: null 유지.
+
+## 8. 메모리 정정
+
+- 없음 — bkit baseline 6/6 직접 재측정 일치 (v2.1.22 / agents 40 (model: 40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2 servers)
+- **다음 baseline**: v2.1.162 (다음 분석 v2.1.163부터)

--- a/memory/cc_version_history_v2163_v2168.md
+++ b/memory/cc_version_history_v2163_v2168.md
@@ -1,0 +1,90 @@
+---
+name: cc-version-history-v2163-v2168
+description: CC v2.1.162 → v2.1.168 영향 분석 history (ADR 0003 19번째 정식 적용, 6-version multi-delta 46 bullets, v164 true skip R-2, Breaking 0 / Breaking-equivalent 0, 신규 ENH(implement) 0건 15-cycle 연속, 차별화 6/6 streak 갱신 #56293→20 #57317→14 #58904→10(✦10 milestone), 119 consecutive milestone, Phase 1.5 게이트 첫 over-count trap 회피 researcher 47→raw 46 v166 22→21, OTEL 모니터 STAYS ACTIVE v163~168 OTEL 0건, 아키텍처 6/6 재측정 정정 없음, 유지보수 발견 MF-1 cc-version-checker RECOMMENDED_VERSION 2.1.118 ~50릴리스 stale flag-only)
+metadata:
+  type: project
+---
+
+# CC v2.1.162 → v2.1.168 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-08
+- **분석 대상**: CC v2.1.162 → v2.1.168 (**6-version multi-delta** — v163/165/166/167/168 신규, v164 결번)
+- **게시**: 전부 npm 게시자 wolffiex, installed=2.1.168
+- **baseline**: v2.1.162 (직전 분석 완료)
+- **R-2 true skip**: **1건 (v164)** — npm 404 + GitHub release 404 + CHANGELOG 헤더 부재 3-source 확정. 누적 skip: v134/135/151/155/164
+- **Total bullets (raw 검증)**: 46 (v163=22 / v166=21 / v165·167·168 placeholder 1 each = 3)
+- **dist-tags**: latest=2.1.168 / stable=2.1.153 / next=2.1.168 / installed=2.1.168
+- **ADR 0003 적용**: **19번째 정식 적용**
+- **누적 연속 호환**: 114 → **119** (v2.1.34 ~ v2.1.168, R-2 v134/135/151/155/164 skip 미포함, +5 게시)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking**: 0건 / **Breaking-equivalent**: 0건
+- **auto-benefit**: 3건 (v163 #4 Stop/SubagentStop additionalContext가 hook-error 아닌 턴 지속 — bkit 이미 사용 / v163 #16 hook `if:` subshell·backtick 매칭 / v163 #9 `$TMPDIR` 전역 override 회귀(2.1.154) 복구)
+- **신규 ENH(implement)**: 0건 (**15-cycle 연속**) — fallbackModel 가이드 / version-pin 문서 후보 둘 다 Deferred(doc-only, 번호 미소비)
+- **마지막 ENH 번호**: ENH-328 (변동 없음, ENH-329 미소비 유지, ENH-317 CANCELLED 유지)
+- **권장 CC**: v2.1.168 즉시 격상 / 보수적 stable v2.1.153 drift +15 CRITICAL
+
+## 3. Phase 1.5 게이트 — 첫 over-count trap 회피 (핵심 학습)
+
+- cc-version-researcher 보고: v166=22 (자가 caveat: "model-parsed boundary, not byte-exact")
+- 메인 세션 raw CHANGELOG.md + GitHub release tag 이중 fetch: **v166=21 (양 소스 byte-identical)** → raw 채택
+- 직전 4개 cycle(v2.1.16/145/161/162)은 전부 **under-count** 패턴 → 본 cycle은 **첫 over-count 패턴**. 게이트가 양방향 오차 모두 포착 입증
+- Total: researcher 47 → raw **46** (errata −1)
+- spot-check 3건 verbatim 일치: v166 #2(deny glob `"*"`) / v166 #3(SendMessage authority) / v163 #17(`Read(~/Desktop/**)` `$HOME`)
+
+## 4. bkit-relevant 플래그 실측 (전부 Neutral/auto-benefit, 0 부착)
+
+| Bullet | 검증 | 결과 |
+|--------|------|------|
+| v163 #4 Stop/SubagentStop additionalContext | `subagent-stop-handler.js:124-131` grep | 이미 구현(nextActionHint) → auto-benefit (Diff#1/#5 native 강화). 메인 세션 직접 재확인 |
+| v163 #16 hook `if:` subshell 매칭 | heredoc-detector 의미 분석 | predicate 매칭 변경뿐, heredoc-body 사각지대 그대로 → Diff#6 약화 없음, 수정 불필요 |
+| v163 #17 / v166 #2 deny `$HOME` / glob | settings.json 배포 grep | **bkit settings.json 미배포** → Neutral |
+| v166 #3 SendMessage authority | dispatcher 검토 | **Task spawn 사용(≠SendMessage)** → Diff#3 무관 |
+| v163 #5 Skills `\$` escape | command body grep | 유일 매치는 prose(`$3/Mtok`) → 무관 |
+| v163 #6 / v166 #16 MCP env/`${VAR}` | .mcp.json | predicate/timeout 필드 0개 → no-op |
+| v166 #1 fallbackModel | agents frontmatter | per-agent `model:` 고정, 세션 설정 무관 → Neutral |
+| v163 #1 managed version-gate | bkit 배포 모델 | plugin은 managed settings 미소유 → 부착점 없음 |
+
+## 5. 차별화 6/6 streak 갱신
+
+| Issue | ENH | v2162 | v2168 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 P0 | 19 | **20** | v163~168 caching bullet 0건 |
+| #57317 PostToolUse drop | ENH-303 P1 | 13 | **14** | v163 #4는 Stop/SubagentStop, PostToolUse drop 무관 |
+| #58904 heredoc bypass | ENH-310 P1 | 9 | **10 ✦** | v163 #16과 별개(권한시스템 heredoc-body 사각지대 미해결) |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+**핵심 구분**: v163 #16 = CC가 사용자 hook `if:` 평가 시 subshell/backtick 매칭하는 fix. #58904(Diff#6) = CC **권한 시스템**이 heredoc body 위험명령 미검사하는 사각지대. 별개 layer → bkit heredoc-detector.js 유효.
+
+## 6. R-Series + Drift
+
+| 패턴 | 본 delta | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | placeholder note이나 CHANGELOG+release 존재 |
+| R-2 true semver skip | **+1 (v164)** | 3-source 확정 |
+| R-3 hotfix chain | +0 | 연쇄 징후 없음 |
+
+- release_drift_score: stable=2.1.153 / latest=2.1.168 → drift +15 (CRITICAL ≥8, 역대 최대). prior batch stable 2.1.152→2.1.153 전진.
+
+## 7. OTEL Monitor
+
+MON-CC-NEW-BG-OTEL-DROP (#64436): v163~168 OTEL bullet 0건. STAYS ACTIVE, expectedFix: null 유지.
+
+## 8. 유지보수 발견 (MF-1) — ENH와 별개
+
+- **위치**: `lib/infra/cc-version-checker.js:40` `const RECOMMENDED_VERSION = '2.1.118';`
+- **문제**: 현 latest/installed 2.1.168 대비 ~50릴리스 stale (MEMORY 권장선 보수 2.1.123 / 균형 2.1.140과도 불일치)
+- **조치**: 본 cycle은 **flag만** (분석 전용 스킬 + No Guessing — 팀이 지원 floor 결정 필요)
+- **권고**: 별도 작업으로 정책 갱신. 분기 로직(`:198~203`)은 정상
+
+## 9. 메모리 정정
+
+- 없음 — bkit baseline 6/6 직접 재측정 일치 (v2.1.22 / agents 40 (model 40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2)
+- 신규 판정 근거: **"no settings.json — hook-based defense"** → 향후 CC의 deny/allow/managed-settings 변경은 bkit 부착점 0으로 자동 Neutral 판정
+- SessionStart preflight "34 agents/174 lib"는 stale 표기 — 채택하지 않음 (실측 40/190)
+- **다음 baseline**: v2.1.168 (다음 분석 v2.1.169부터)

--- a/memory/cc_version_history_v2169.md
+++ b/memory/cc_version_history_v2169.md
@@ -1,0 +1,90 @@
+---
+name: cc-version-history-v2169
+description: CC v2.1.168 → v2.1.169 영향 분석 history (ADR 0003 20번째 정식 적용 ✦, 1-version 실질 delta 30 bullets placeholder 아님, Breaking 0 / Breaking-equivalent 0, auto-benefit 6건, 신규 ENH(implement) 0건 16-cycle 연속, 차별화 6/6 streak 갱신 #56293→21 #57317→15 #58904→11, 120 consecutive milestone ✦, Phase 1.5 게이트 tail-total 산술오류 회피 researcher 30 / WebFetch 자가총계 38·31 오산 / 메인 수동열거 30 확정, OTEL 모니터 #64436 + skill_post plugin-hook-drop 모니터 둘 다 STAYS ACTIVE, 아키텍처 6/6 재측정 정정 없음, MF-1 RECOMMENDED_VERSION 2.1.118 stale 2-cycle carry-forward)
+metadata:
+  type: project
+---
+
+# CC v2.1.168 → v2.1.169 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-09
+- **분석 대상**: CC v2.1.168 → v2.1.169 (**1-version delta**, v169 신규 실질 30-bullet 엔트리 — placeholder 아님)
+- **게시**: 2026-06-08 21:57 UTC, GitHub author @ashwin-ant / npm publisher wolffiex (양립)
+- **baseline**: v2.1.168 (직전 분석 완료)
+- **R-2 true skip**: 0건 (v168→v169 연속, triple-present). 누적 skip 변동 없음: v134/135/151/155/164
+- **Total bullets (raw 검증)**: 30 (Added 3 / Fixed 14 / Improved·Other 13, flat list)
+- **dist-tags**: latest=2.1.169 / stable=2.1.153 / next=2.1.169 / installed=2.1.169
+- **ADR 0003 적용**: **20번째 정식 적용 ✦**
+- **누적 연속 호환**: 119 → **120 ✦** (v2.1.34 ~ v2.1.169, R-2 v134/135/151/155/164 skip 미포함)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking**: 0건 / **Breaking-equivalent**: 0건
+- **auto-benefit**: 6건 (#5 managed MCP allow/deny 강제 누락 fix / #14 pre-warmed worker project env(ANTHROPIC_MODEL) drop fix → Diff#3 dispatch 결정성 / #16 plugin .in_use PID lock GC → bkit=plugin 수혜 / #17 untrusted OTEL client-cert trust fix / #19 TaskCreate 자동복구 / #23 managed-settings invalid-entry 부분적용)
+- **신규 ENH(implement)**: 0건 (**16-cycle 연속**) — #1 safe-mode 문서화 후보 P3 DEFER(번호 미소비)
+- **마지막 ENH 번호**: ENH-328 (변동 없음, ENH-329 미소비 유지, ENH-317 CANCELLED 유지)
+- **권장 CC**: v2.1.169 즉시 격상 / 보수적 stable v2.1.153 drift +16 CRITICAL (역대 최대)
+
+## 3. Phase 1.5 게이트 — tail-total 산술오류 회피 (핵심 학습, 신규 패턴)
+
+- cc-version-researcher 보고: 30 (정확)
+- 메인 세션 raw CHANGELOG.md + GitHub release tag 이중 fetch: **verbatim 리스트 완전 동일(30개)**, 그러나 두 WebFetch가 자기 리스트 꼬리 "Total"을 각각 **38 / 31로 오산**
+- 메인 세션 행 단위 직접 열거 → **30 확정**
+- **신규 errata 패턴**: 직전 cycle들은 model이 bullet *누락/병합*하는 miscount(under/over-count)였으나, 본 cycle은 **리스트는 정확·합산만 틀린 산술오류**. → 게이트 정답은 "model이 보고한 Total"이 아니라 **"열거된 verbatim 리스트 직접 카운트"**. 두 소스 verbatim 동일성이 신뢰 근거
+- spot-check 3건 verbatim 일치: #5(managed MCP) / #14(bg env) / #17(OTEL client-cert)
+
+## 4. bkit-relevant 플래그 실측 (priority deep-dive)
+
+| Bullet | 검증 | 결과 |
+|--------|------|------|
+| #1 `--safe-mode`/CLAUDE_CODE_SAFE_MODE | repo grep 0건 + 의미분석 | bkit 로드 前 CC레벨 전체 차단(CLAUDE.md+plugins+skills+hooks+MCP). bkit 저항 불가·불필요(의도된 동작). 부착점 0. P3 doc 후보만 |
+| #3 disableBundledSkills/CLAUDE_CODE_DISABLE_BUNDLED_SKILLS | skills/bkit/SKILL.md 분류 | "bundled"=CC 내장 한정. bkit 44 skills=plugin-provided → 무관 |
+| #12 `claude agents --json` id/state/--all | grep "agents --json" lib/scripts/hooks | bkit parser 0건 → Neutral |
+| #14 bg env(ANTHROPIC_MODEL) drop fix | sub-agent-dispatcher.js | Diff#3 sequential dispatch 결정성↑ → auto-benefit MEDIUM |
+| #16 plugin .in_use PID lock GC | bkit=plugin runtime | stale marker 일일 sweep → 자원누수 방지 auto-benefit LOW |
+| #19 TaskCreate 자동복구 | scripts/task-created-handler.js | 방어적 read+exit-0 fallback 이미 존재 → 위험 없음 auto-benefit MEDIUM |
+| #26 CLAUDE.md threshold context-scaling | memory-enforcer.js + 하드코딩 grep | bkit CLAUDE.md 크기 gate 미하드코딩(memory-enforcer 240/200=directive 추출, context-sizer 100K=토큰예산) → Neutral |
+| #5/#23 managed MCP/부분적용 | .mcp.json + settings 배포 | bkit settings.json 미배포 → governance auto-benefit |
+| #17 untrusted OTEL client-cert | grep CLIENT_CERTIFICATE lib/ 0건 + otel-env-capturer.js | 신뢰된 USER shell env 캡처(project settings 아님) → 노출 없음 Neutral |
+
+## 5. 차별화 6/6 streak 갱신
+
+| Issue | ENH | v2168 | v2169 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 P0 | 20 | **21** | v169 #2 `/cd`는 cache 보존 신기능, invalidation 미해결 |
+| #57317 PostToolUse drop | ENH-303 P1 | 14 | **15** | PostToolUse 변경 0건 + skill_post plugin-hook-drop reachability 미해결 |
+| #58904 heredoc bypass | ENH-310 P1 | 10 | **11** | bash-parsing 변경 0건, Diff#6 독립 면역 유지 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+## 6. R-Series + Drift
+
+| 패턴 | 본 delta | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | full CHANGELOG + release |
+| R-2 true semver skip | +0 | 연속, triple-present |
+| R-3 hotfix chain | +0 | #7은 2.1.161 회귀 단발 fix |
+
+- release_drift_score: stable=2.1.153 / latest=2.1.169 → drift +16 (CRITICAL ≥8, 역대 최대). stable 정체(2.1.153).
+
+## 7. Monitor 상태 (2건 모두 STAYS ACTIVE)
+
+- **MON-CC-NEW-BG-OTEL-DROP (#64436)**: v169 유일 OTEL bullet #17은 client-cert **trust** fix로 shutdown-flush metric-drop과 별개. STAYS ACTIVE, expectedFix: null.
+- **MON-CC-NEW-PLUGIN-HOOK-DROP (#57317, skill_post)**: 본 세션 preflight `missing=[skill_post]` 재발. v169 plugin bullet #15(MCPB cache)/#16(PID lock GC)은 hook reachability 미터치. STAYS ACTIVE.
+
+## 8. 유지보수 발견 (MF-1) — 2-cycle carry-forward
+
+- **위치**: `lib/infra/cc-version-checker.js:40` `const RECOMMENDED_VERSION = '2.1.118';` (직전 cycle 이후 변동 없음, Read 재확인)
+- **문제**: 현 latest 2.1.169 대비 ~51릴리스 stale (MEMORY 권장선 보수 2.1.123 / 균형 2.1.140과도 불일치)
+- **조치**: flag 유지(미수정) — 분석 전용 + No Guessing(팀이 지원 floor 결정)
+- **권고**: 다음 일반 PDCA에서 우선 처리. 분기 로직(:198~203) 정상
+
+## 9. 메모리 정정
+
+- 없음 — bkit baseline 6/6 직접 재측정 일치 (v2.1.22 / agents 40 (40/40) / skills 44 / lib 190 modules 22 subdirs / MCP 2)
+- "no settings.json — hook-based defense" 판정 근거 재확인: #5/#17/#23 managed/OTEL governance 변경 = bkit 부착점 0 자동 Neutral
+- SessionStart preflight "34 agents/174 lib" stale 표기 — 채택하지 않음 (실측 40/190)
+- **다음 baseline**: v2.1.169 (다음 분석 v2.1.170부터)

--- a/memory/cc_version_history_v2170_v2179.md
+++ b/memory/cc_version_history_v2170_v2179.md
@@ -1,0 +1,101 @@
+---
+name: cc-version-history-v2170-v2179
+description: CC v2.1.169 → v2.1.179 영향 분석 history (ADR 0003 21번째 정식 적용 ✦, 10-version delta 102 bullets gh-API authoritative, Breaking 0 / Breaking-equivalent 0, auto-benefit 4건 헤드라인=v176 hook `if` Read/Edit/Write 매칭 fix MEDIUM, 신규 ENH(implement) 0건 17-cycle 연속, ENH-367 예약 미소비, 차별화 6/6 streak 갱신 #56293→22 #57317→16 #58904→12, 128 consecutive milestone ✦, Phase 1.5 게이트 model-WebFetch under/over-count 회피 gh-API base64 디코딩 102 확정, CHANGELOG floor v132 발견, R-2 skip +2 v171/v177, monitor 4건 전부 유지 BG-OTEL-DROP/PLUGIN-HOOK-DROP/CHOICE-LOOP ACTIVE + STOP-SCHEMA-STRICT RESOLVED, dist-tags stable 2.1.153→2.1.169 따라잡음 drift +16→+10, MF-1 RECOMMENDED_VERSION 2.1.118 3-cycle carry-forward)
+metadata:
+  type: project
+---
+
+# CC v2.1.169 → v2.1.179 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-17
+- **분석 대상**: CC v2.1.169 → v2.1.179 (**10-version delta**)
+- **baseline**: v2.1.169 (직전 분석 완료)
+- **present 8버전**: v170(2) v172(30) v173(2) v174(13) v175(1) v176(22) v178(23) v179(9) = **102 bullets**
+- **R-2 true skip**: **+2건 (v171, v177)** — changelog floor v132 위 retained 범위 내 부재 = 진성 semver skip. 누적: v134/135/151/155/164/171/177
+- **dist-tags**: latest=2.1.179 / stable=2.1.169 / next=2.1.179 / installed=2.1.179
+- **ADR 0003 적용**: **21번째 정식 적용 ✦**
+- **누적 연속 호환**: 120 → **128 ✦** (v2.1.34 ~ v2.1.179, +8 present, R-2 skip 7건 미포함)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking**: 0건 / **Breaking-equivalent**: 0건
+- **auto-benefit**: 4건 — **[헤드라인] v176 hook `if` Read/Edit/Write 매칭 fix(MEDIUM)** / v179 plugin 로딩 성능 remote(LOW) / v178 subagent transcript·메시지·backgrounding fix(DX LOW) / v178 auto-mode subagent classifier 사전평가(security LOW)
+- **신규 ENH(implement)**: 0건 (**17-cycle 연속**) — 모든 후보 YAGNI 탈락(DROP/P3)
+- **마지막 ENH 번호**: ENH-328(CC-cycle) / 전역 ENH-366(내부 하드닝 소비), **ENH-367 예약 미소비**
+- **권장 CC**: v2.1.179 즉시 격상 / stable 2.1.169 drift +10 CRITICAL band (직전 +16에서 개선)
+
+## 3. 헤드라인 — v2.1.176 hook `if` 매칭 수정 (auto-benefit MEDIUM, 핵심 학습)
+
+- **CC bullet**: "Fixed hook `if` conditions for Read/Edit/Write tool paths: documented patterns like `Edit(src/**)`, `Read(~/.ssh/**)`, `Read(.env)` now match correctly"
+- **bkit 부착점 실측**: `hooks/hooks.json:30` `"if": "Write(skills/**/SKILL.md)"` / `hooks/hooks.json:275` `"if": "Write|Edit(docs/**/*.md)"` — bkit는 if-gated 훅 **실제 2건 사용**
+- **판정**: bkit 패턴은 이미 수정된 documented syntax 사용 + 두 핸들러가 경로 **자체 가드(self-guard)** → pre-2.1.176 매칭 갭에서도 오발화/누락 무해. 2.1.176은 silent-gap 신뢰성 위험 제거의 순수 이득, breakage·조치·테스트 불필요
+- **신규 패턴**: 직전 cycle들은 bkit이 settings/CLAUDE.md/managed-MCP에 부착점 0(Neutral)이었으나, 본 cycle은 **bkit이 CC 수정 대상 기능(hook `if:`)을 실제 사용 중이면서도 self-guard로 회귀 면역**인 첫 auto-benefit 케이스
+
+## 4. Phase 1.5 게이트 — model-WebFetch under/over-count 회피 (gh-API 디코딩)
+
+- 1차 model-processed WebFetch: 179=11 178=16 176=13 174=11 172=27 (대부분 과소, v179만 과다)
+- ground truth: `gh api repos/anthropics/claude-code/contents/CHANGELOG.md --jq .content | base64 -d` → 179=9 178=23 176=22 174=13 172=30 → **Total 102 확정**
+- **게이트 정답**: model 응답이 아니라 **gh-API base64 디코딩 raw 파일 행 단위 직접 열거**
+- **CHANGELOG floor 발견 (researcher)**: rolling CHANGELOG.md@main 하한 = **v2.1.132**. v69~v131은 prune(존재했으나 제거, R-2 skip과 구별). 본 범위 v170~v179는 floor 위 retained → R-2 판정 신뢰 가능
+- spot-check 3건 verbatim: v176(hook if) / v172(sub-agent 5단계) / v178(Tool(param:value))
+
+## 5. bkit-relevant 플래그 실측
+
+| Bullet | 검증 | 결과 |
+|--------|------|------|
+| v176 hook `if` 매칭 fix | hooks.json 2개 if 블록 + self-guard | **auto-benefit MEDIUM** (헤드라인) |
+| v172 sub-agents 5단계 중첩 | sub-agent-dispatcher.js / team-protocol.js | sequential dispatch 자체 오케스트레이션, CC 중첩과 직교, #56293 무영향 → Neutral |
+| v172 availableModels subagent override fix | settings.json 미배포 | Neutral governance |
+| v178 Tool(param:value) 권한 문법 | hook 기반 방어, settings 룰 아님 | Neutral (향후 옵션이나 YAGNI) |
+| v178 nested .claude/skills + precedence | bkit=plugin-provided skills/output-styles | Neutral (사용자 override 가능성 note) |
+| v178 subagent transcript/backgrounding fix | bkit Task spawn 다용 | DX auto-benefit LOW |
+| v178 MCP spec subagent disallowedTools fix | bkit agents disallowedTools mcp__* 미사용 | Neutral |
+| v178 auto-mode subagent classifier 사전평가 | auto-mode | security governance auto-benefit LOW |
+| v172 model attr OTEL lines_of_code.count | MON-CC-NEW-BG-OTEL-DROP | additive 속성, shutdown-flush와 별개 → 미해결 |
+| v175/v176 managed setting | settings.json 미배포 | Neutral (no-settings-json-defense 일관) |
+| v179 plugin 로딩 성능 remote | bkit=plugin | auto-benefit LOW |
+
+- **Hook 스키마 변경 0건** (additionalContext=v163, terminalSequence=v141, background_tasks=v145 전부 baseline 이하). PreToolUse/PostToolUse/Stop/SubagentStop 입출력 스키마 본 범위 변경 0 → contract test 갱신 불필요
+
+## 6. 차별화 6/6 streak 갱신
+
+| Issue | ENH | v169 | v179 | 비고 |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292 P0 | 21 | **22** | v172 5단계 중첩=depth 기능, parallel-spawn cache invalidation 미해결(오히려 cache-cost 표면 확대) |
+| #57317 PostToolUse drop | ENH-303 P1 | 15 | **16** | v178 MCP disallowedTools fix는 인접 표면(hook drop 아님), skill_post reachability 미해결 |
+| #58904 heredoc bypass | ENH-310 P1 | 11 | **12** | 102 bullets 중 heredoc 0건, v178 Tool(param:value)은 heredoc-body 맹점 무관 |
+
+surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+## 7. R-Series + Drift
+
+| 패턴 | 본 delta | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | 전 present 버전 full CHANGELOG entry |
+| R-2 true semver skip | **+2** | v171, v177 (floor 위 retained 부재). 누적 7건 |
+| R-3 hotfix chain | +0 | v179 mid-stream fix 단발 |
+
+- release_drift_score: stable=2.1.169 / latest=2.1.179 → **drift +10 (CRITICAL ≥8, 직전 +16에서 개선)**. stable 2.1.153→2.1.169로 16릴리스 따라잡음
+
+## 8. Monitor 상태 (4건 전부 유지)
+
+- **MON-CC-NEW-BG-OTEL-DROP (#64436)**: v172 OTEL `model` attr는 additive, shutdown-flush metric-drop과 별개. STAYS ACTIVE, expectedFix: null
+- **MON-CC-NEW-PLUGIN-HOOK-DROP (#57317 skill_post)**: v178 plugin/subagent fix는 disallowedTools·transcript 표면뿐 hook reachability 미터치. STAYS ACTIVE
+- **MON-CC-NEW-CHOICE-LOOP**: 본 범위 관련 bullet 0건. STAYS ACTIVE
+- **MON-CC-NEW-STOP-SCHEMA-STRICT (ENH-366 P0)**: 본 범위 Stop hook 출력 스키마 변경 0건. STAYS RESOLVED
+
+## 9. 유지보수 발견 (MF-1) — 3-cycle carry-forward
+
+- **위치**: `lib/infra/cc-version-checker.js:40` `const RECOMMENDED_VERSION = '2.1.118';` (3-cycle 변동 없음)
+- **문제**: 현 latest 2.1.179 대비 ~61릴리스 stale
+- **조치**: flag 유지(미수정) — 분석 전용 + No Guessing(팀이 지원 floor 결정)
+- **권고**: 다음 일반 PDCA에서 우선 처리
+
+## 10. 메모리 정정
+
+- 없음 — bkit baseline 재측정 일치 (v2.1.22 / agents 40 / skills 44 / lib 190 modules 22 subdirs)
+- SessionStart preflight "34 agents/174 lib" stale 표기 — 채택하지 않음 (실측 40/190)
+- **다음 baseline**: v2.1.179 (다음 분석 v2.1.180부터)

--- a/memory/cc_version_history_v2180_v2181.md
+++ b/memory/cc_version_history_v2180_v2181.md
@@ -1,0 +1,97 @@
+---
+name: cc-version-history-v2180-v2181
+description: CC v2.1.179 → v2.1.181 영향 분석 history (ADR 0003 22번째 정식 적용 ✦, v181만 present 39 bullets / v180 R-2 진성 skip npm404, Breaking 0 / Breaking-equivalent 0, auto-benefit 6건 헤드라인=#34 AskUserQuestion multi-select Other-drop fix MEDIUM, 신규 ENH(implement) 0건 18-cycle 연속 ENH-367 예약 유지, 차별화 streak #56293→23 #57317→17 #58904→13, ⚠️신규신호 #56293·#57317 not_planned 종료=moat강화 streak break아님, MON-CC-NEW-CHOICE-LOOP=#64447 liveness STAYS ACTIVE #34는 별개버그, monitor 4건 전부 유지, Phase 1.5 gh-API base64 직행 39확정 model-WebFetch우회, R-2 skip+1 v180, R-3 hotfix #14 2.1.169회귀, 129 consecutive milestone, dist-tags stable2.1.170/latest2.1.181 drift+11, MF-1 RECOMMENDED_VERSION 2.1.118 4-cycle carry)
+metadata:
+  type: project
+---
+
+# CC v2.1.179 → v2.1.181 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-18
+- **분석 대상**: CC v2.1.179 → v2.1.181 (**v181만 present 39 bullets**)
+- **baseline**: v2.1.179
+- **R-2 true skip**: **+1건 (v180)** — npm E404 + changelog floor(v132) 위 부재 이중 확인. 누적: v134/135/151/155/164/171/177/180 (8건)
+- **dist-tags**: latest=next=2.1.181 / stable=2.1.170 / installed=2.1.181
+- **ADR 0003 적용**: **22번째 정식 적용 ✦**
+- **누적 연속 호환**: 128 → **129 ✦** (v2.1.34 ~ v2.1.181, +1 present, R-2 skip 8건 미포함)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking**: 0건 / **Breaking-equivalent**: 0건
+- **auto-benefit**: 6건 — **[헤드라인] #34 AskUserQuestion multi-select Other-drop fix(MEDIUM, bkit AskUserQuestion 의무 사용)** / #33 preview word-wrap(LOW) / #7 subagent 패널(LOW) / #21 subagent Thinking 표시(LOW) / #22 subagent waiting 표시(LOW) / #11 Foundry·base_url prompt caching(LOW)
+- **Neutral**: 33건
+- **신규 ENH(implement)**: 0건 (**18-cycle 연속**) — 모든 후보 YAGNI 탈락
+- **마지막 ENH 번호**: ENH-328(CC-cycle) / 전역 ENH-366, **ENH-367 예약 유지(미소비)**
+- **권장 CC**: **stable v2.1.170 pin** (latest 2.1.181 허용 가능, Breaking 0이나 11-bullet runtime/startup churn). drift +11 CRITICAL
+
+## 3. 헤드라인 — #34 ↔ MON-CC-NEW-CHOICE-LOOP (핵심 판정)
+
+- **#34 verbatim**: "Fixed AskUserQuestion multi-select questions silently dropping a typed Other free-text answer when submitting"
+- **GitHub 이슈(리서처)**: #68235 2026-06-16 종료 (high-confidence-inferred)
+- **CHOICE-LOOP 실측**: `lib/cc-regression/registry.js:151-158` → **MON-CC-NEW-CHOICE-LOOP = #64447 (liveness/무한루프)**
+- **판정**: **CHOICE-LOOP STAYS ACTIVE** — #34/#68235는 multi-select Other-drop = **correctness** 버그로 #64447 **liveness**와 별개. 리서처 추론 이슈번호와 모니터 추적 이슈가 다름을 분석가가 정독으로 확정 (엄밀 판정 사례)
+- **bkit 영향**: #34는 bkit 의무 AskUserQuestion(SessionStart+스킬) 신뢰성↑ auto-benefit MEDIUM. 인접 미해결 #62006/#68417는 향후 모니터 후보(P3)
+
+## 4. Phase 1.5 게이트 — gh-API 직행 (model-WebFetch 우회)
+
+- 직전 cycle(v170-179) model-WebFetch under/over-count 교훈 반영 → **처음부터 `gh api contents/CHANGELOG.md | base64 -d` 행 단위 열거** → count 불일치 0
+- v181 = **39 bullets** 확정 (Added 4 / Improved 5 / Changed 2 / Fixed 28)
+- v180 R-2 진성 skip 이중 확인: npm E404 + changelog floor 위 부재 (R-1 silent publish 아님)
+- spot-check 3건: #19(subagent depth) / #34(AskUserQuestion Other) / #11(Foundry caching)
+
+## 5. bkit-relevant 플래그 실측
+
+| Bullet | 검증 (파일) | 결과 |
+|--------|-----------|------|
+| #34 AskUserQuestion Other-drop fix | registry.js:151-158 (CHOICE-LOOP=#64447) | auto-benefit MEDIUM (헤드라인, CHOICE-LOOP 별개) |
+| #33 AskUserQuestion preview wrap | bkit preview 사용 | auto-benefit LOW |
+| #19 foreground subagent 5단계 depth limit | sub-agent-dispatcher.js(중첩 spawn 없음)+team-protocol.js:6-7(1-level) | bkit 1-level dispatch → cap 도달 불가. Neutral |
+| #11 Foundry·base_url prompt caching | docs/03-analysis/prompt-caching-optimization.md:6 | attestation token 축, #56293과 직교. Neutral(Foundry만 LOW) |
+| #14 startup 회귀 ~120ms (2.1.169 도입) | .mcp.json (MCP 2개) | fix 조건=no-MCP, bkit는 MCP 2개 → Neutral (R-3 신호) |
+| #7/#21/#22 subagent 패널·표시 | bkit Task spawn | DX auto-benefit LOW |
+| #1/#2/#3 /config·allowAppleEvents·presence-file | settings.json 미배포 | Neutral |
+
+- **Hook 스키마 변경 0건**. PreToolUse/PostToolUse/Stop/SubagentStop 변경 0 → contract test 불필요
+
+## 6. 차별화 streak 갱신 + ⚠️ not_planned 종료 신호
+
+| Issue | ENH | v179 | v181 | 이슈 상태 | 비고 |
+|-------|-----|:---:|:---:|------|------|
+| #56293 caching 10x | ENH-292 P0 | 22 | **23** | **CLOSED not_planned (06-02)** | #19·#11은 직교축. moat intact |
+| #57317 PostToolUse drop | ENH-303 P1 | 16 | **17** | **CLOSED not_planned (06-06)** | plugin-hook reachability bullet 0건 |
+| #58904 heredoc bypass | ENH-310 P1 | 12 | **13** | **OPEN** (security, 06-05) | heredoc bullet 0건 |
+
+- **⚠️ 신규 패턴 — not_planned housekeeping 종료**: #56293·#57317이 며칠 간격 코드 fix 없이 not_planned 종료. **streak break 아님**("닫힘≠고침"). Anthropic 미수정 의사 → bkit workaround 가치 영구화(moat 강화). **향후 streak break 판정은 code-fix bullet에만 의존, 이슈 종료 상태 무시**. (differentiator-streaks 에이전트 메모리 반영 완료)
+- surface 3/3 code-active: sub-agent-dispatcher.js / unified-bash-post.js / heredoc-detector.js
+
+## 7. R-Series + Drift
+
+| 패턴 | 본 delta | 비고 |
+|------|:---:|------|
+| R-1 silent npm publish | +0 | v181 full entry, v180 미발행(R-1 아님) |
+| R-2 true semver skip | **+1** | v180 (npm E404). 누적 8건 |
+| R-3 hotfix chain | **+1** | #14 startup 회귀(2.1.169 도입→2.1.181 fix) |
+
+- release_drift_score: stable=2.1.170 / latest=2.1.181 → **drift +11 (CRITICAL ≥8)**. 직전 +10과 유사
+
+## 8. Monitor 상태 (4건 전부 유지)
+
+- **MON-CC-NEW-BG-OTEL-DROP (#64436)**: v181 OTEL bullet 0건. STAYS ACTIVE
+- **MON-CC-NEW-PLUGIN-HOOK-DROP (#57317)**: v181 reachability bullet 0건, 이슈 not_planned 종료(코드 fix 아님). STAYS ACTIVE
+- **MON-CC-NEW-CHOICE-LOOP (#64447 liveness)**: v181 #34는 별개 correctness 버그, #64447 미해결. STAYS ACTIVE
+- **MON-CC-NEW-STOP-SCHEMA-STRICT (ENH-366 P0)**: v181 Stop hook 출력 스키마 변경 0건. STAYS RESOLVED
+
+## 9. 유지보수 발견 (MF-1) — 4-cycle carry-forward
+
+- **위치**: `lib/infra/cc-version-checker.js:40` `const RECOMMENDED_VERSION = '2.1.118';` (4-cycle 변동 없음). MIN_VERSION='2.1.78'(:34)
+- **문제**: stable 2.1.170 대비 ~52릴리스 stale
+- **조치**: flag 유지(미수정) — 분석 전용 + No Guessing
+- **권고**: 다음 하드닝 스프린트에서 team-set floor ≥2.1.170 bump
+
+## 10. 메모리 정정
+
+- 없음 — bkit baseline 재측정 일치 (v2.1.22 / agents 40 / skills 44 / lib 190 modules 22 subdirs / MCP 2)
+- **다음 baseline**: v2.1.181 (다음 분석 v2.1.182부터)

--- a/memory/cc_version_history_v2181_v2191.md
+++ b/memory/cc_version_history_v2181_v2191.md
@@ -1,0 +1,81 @@
+---
+name: cc-version-history-v2181-v2191
+description: CC v2.1.181 → v2.1.191 영향 분석 history (ADR 0003 23번째 정식 적용 ✦, 6 문서화 버전 present 93 bullets[183:17/185:1/186:33/187:21/190:1/191:20], v182 R-1 silent publish / v184·188·189 R-2 진성 skip, Breaking changelog 0 / CC Breaking-equivalent 2건[respondToBashCommands·MAX_RETRIES cap]이나 bkit 노출 0건, 헤드라인=comma-matcher hook fix v191 bkit 구조적 면역[pipe 컨벤션 100%], 실질 auto-benefit 헤드라인=v183 WebSearch-empty-in-subagents fix MEDIUM[cc-version-researcher/pm-research 직접 수혜], auto-benefit 5건, 신규 ENH implement 0건 19-cycle 연속 ENH-367 예약 유지[destructive-detector 확장 후보 Deferred], 차별화 streak #56293→24 #57317→18 #58904→14 3대 이슈 전부 CC-abandoned[#58904 OPEN→not_planned 전환 = moat 영구화], monitor 4건 전부 유지[CHOICE-LOOP=#64447 closed-as-dup이나 liveness 미수정 STAYS ACTIVE], R-1 silent +1[v182] R-2 skip +3[v184/188/189] 누적11 R-3 hotfix #7[v187 2.7s 회귀], 136 consecutive milestone, dist-tags stable2.1.179/latest2.1.191 drift+12 CRITICAL, Numeric Correction Protocol 적용[analyst stale stable2.1.170/drift+21/~135 → 메인 직접측정 stable2.1.179/drift12/136 raw-wins], MF-1 RECOMMENDED_VERSION 2.1.118 5-cycle carry)
+metadata:
+  type: project
+---
+
+# CC v2.1.181 → v2.1.191 영향 분석 history
+
+## 1. 메타데이터
+
+- **분석 일자**: 2026-06-26
+- **분석 대상**: CC v2.1.181 → v2.1.191 (**6 문서화 버전 present**: 183/185/186/187/190/191, 총 **93 bullets**)
+- **baseline**: v2.1.181
+- **R-1 silent publish**: **+1건 (v182)** — npm 존재 / changelog 미문서
+- **R-2 true skip**: **+3건 (v184/188/189)** — npm E404 + changelog 부재. 누적: v134/135/151/155/164/171/177/180 + v184/188/189 = **11건**
+- **dist-tags**: latest=next=2.1.191 / stable=2.1.179 / installed=2.1.191
+- **ADR 0003 적용**: **23번째 정식 적용 ✦**
+- **누적 연속 호환**: 129 → **136 ✦** (v2.1.34 ~ v2.1.191, +7 present[v182,183,185,186,187,190,191], R-2 skip 11건 미포함)
+
+## 2. 최종 판정
+
+- **크리티컬 회귀**: 0건 (bkit v2.1.22 무수정)
+- **Breaking(changelog)**: 0건 / **CC-level Breaking-equivalent**: **2건** (v186 respondToBashCommands 기본값 변경 HIGH / v186 CLAUDE_CODE_MAX_RETRIES 15 cap MED) — **단 bkit attachment surface 노출 0건** (실증: bkit `!` prefix 미사용, MAX_RETRIES 미설정)
+- **auto-benefit**: 5건 — **[실질 헤드라인] v183 WebSearch-empty-in-subagents fix(MEDIUM, cc-version-researcher/pm-research 직접 수혜)** / v191 comma-matcher fix(bkit 면역 검증) / v186 Agent(type) 강제 복원(LOW, #1/#4) / v186 skill frontmatter case+malformed YAML 관용(LOW) / v183 auto-mode destructive-git block(LOW, Defense Layer 6 수렴)
+- **Neutral**: ~85건
+- **신규 ENH(implement)**: 0건 (**19-cycle 연속**) — ENH-367(destructive-detector 확장) Deferred, 모든 후보 YAGNI 탈락
+- **마지막 ENH 번호**: ENH-328(CC-cycle) / 전역 ENH-366, **ENH-367 예약 유지(미소비)**
+- **권장 CC**: **stable v2.1.179 pin** (latest 2.1.191 허용 가능, Breaking 0이나 v186 2-Breaking-equiv + runtime churn). drift +12 CRITICAL
+
+## 3. 헤드라인 — comma-matcher hook fix (v191) bkit 구조적 면역
+
+- **v191 verbatim**: "Fixed hooks with comma-separated matchers (e.g. `\"Bash,PowerShell\"`) silently never firing"
+- **bkit 실측 (메인 세션 직접)**: `hooks/hooks.json` 전수 grep → comma-separated matcher **0건**. 다중-tool matcher 6건 전부 pipe(`|`): `Write|Edit`(L19) / `auto|manual`(L112) / `Bash|Write|Edit`(L190) / `project_settings|skills`(L213) / `Write|Edit|Bash`(L225) / `permission_prompt|idle_prompt`(L237)
+- **판정**: **bkit 구조적 면역** — v191 버그(comma matcher silently-never-firing)는 bkit hook을 한 번도 침범 못함. bkit의 일관된 pipe 컨벤션 결과. auto-benefit = convention validation (silent bkit 버그 fix 아님). → **`hook-matcher-pipe-convention` 메모리화: 차기 cycle matcher-syntax 질문 즉시 Neutral resolve**
+- **실질 positive 헤드라인**: v183 WebSearch-empty-in-subagents fix가 bkit 리서치 에이전트(cc-version-researcher/pm-research)에 직접 수혜 → auto-benefit MEDIUM. 본 cycle Phase 1 리서치 신뢰성에도 직결
+
+## 4. CC Breaking-equivalent 2건 — bkit 노출 0건 (실증)
+
+| Breaking-equiv | 성격 | bkit 노출 실측 | 판정 |
+|----------------|------|---------------|------|
+| v186 respondToBashCommands 기본값(true) | `!` bash 출력 자동 응답 | `!` prefix bkit 미사용(유일 매치 release-plugin-tag.sh:67 = shell 부정 연산자) | Neutral (user-UX 노트만) |
+| v186 CLAUDE_CODE_MAX_RETRIES 15 cap | >15 silently cap | `grep CLAUDE_CODE_MAX_RETRIES` → 0건 | Neutral (미설정) |
+
+→ 직전 cycle "Breaking-equivalent 0건"에서 변화. **CC 차원 2건이나 bkit attachment surface 0건** → 19-cycle 무수정 streak 유지.
+
+## 5. Phase 1.5 게이트 — gh-API base64 직행
+
+- `gh api repos/anthropics/claude-code/contents/CHANGELOG.md --jq '.content' | base64 -d` 행 단위 열거 → **93 bullets 확정**, count 불일치 0
+- v182 R-1 silent: npm `2.1.182` 존재 / changelog 미문서
+- v184/188/189 R-2 진성 skip: npm E404 + changelog 부재 이중 확인
+- spot-check 3건: v191 comma-matcher / v186 respondToBashCommands / v183 destructive-git verbatim
+
+## 6. 차별화 streak 갱신 + ⚠️ 3대 이슈 전부 CC-abandoned
+
+| Issue | ENH | 이전 | 갱신 | 이슈 상태 (본 cycle) |
+|-------|-----|:---:|:---:|------|
+| #56293 caching 10x | ENH-292(P0) | 23 | **24** | CLOSED not_planned |
+| #57317 PostToolUse drop | ENH-303(P1) | 17 | **18** | CLOSED not_planned |
+| #58904 heredoc bypass | ENH-310(P1) | 13 | **14** | **OPEN → CLOSED not_planned ✦** |
+
+- **⚠️ 신규 패턴**: 직전 cycle까지 #58904만 OPEN(security label)이었으나 본 cycle `not_planned` 종료 → **3대 차별화 이슈 전부 CC 수정 포기**(#56293·#57317·#58904 not_planned, #64447 duplicate). streak break 아님("닫힘≠고침"). Anthropic 미수정 의사 확정 → bkit workaround **가치 영구화(moat 최대 강화)**. 향후 streak break 판정은 code-fix bullet에만 의존.
+- surface 3/3 code-active: sub-agent-dispatcher.js / destructive-detector·layer-6-audit / heredoc-detector.js
+
+## 7. R-Series + Monitor + MF
+
+- **R-1 silent**: +1 (v182)
+- **R-2 skip**: +3 (v184/188/189) → 누적 11
+- **R-3 hotfix**: #7 (v187 "Remote sessions ~2.7s longer after agent proxy CA install" 회귀)
+- **release_drift**: stable 2.1.179 / latest 2.1.191 = **12 (CRITICAL ≥8)**
+- **Numeric Correction Protocol 적용 사례**: analyst가 stale stable=2.1.170/drift+21/~135 보고하며 dist-tags 미확보 flag → 메인 세션 `npm view ... dist-tags` 직접 측정 → stable=2.1.179/drift=12/consecutive=136 채택(raw wins). v2.1.16 errata 학습 절차 정상 작동.
+- **Monitor 4건**: BG-OTEL-DROP(#64436) / PLUGIN-HOOK-DROP(#57317 not_planned) / CHOICE-LOOP(#64447 closed-as-dup이나 liveness 미수정) **전부 STAYS ACTIVE**, STOP-SCHEMA-STRICT(ENH-366) STAYS RESOLVED. 신규 등재 0건(#68417 AskUserQuestion Windows ConPTY OPEN = P3 defer)
+- **MF-1 carry-forward**: `lib/infra/cc-version-checker.js:40` RECOMMENDED_VERSION='2.1.118' (MIN='2.1.78':34) — stable 2.1.179 대비 ~61릴리스 stale, **5-cycle 연속 carry**. 다음 하드닝에서 floor ≥2.1.170 bump 권고(팀 결정, No Guessing)
+
+## 8. 메모리 갱신 요약
+
+- New-ENH(implement)-zero streak: 18 → **19**
+- Consecutive compatible: 129 → **136 ✦** (+7 present)
+- Differentiation: #56293=**24** / #57317=**18** / #58904=**14** (3대 전부 CC-abandoned)
+- Architecture baseline: 재측정 일치, 정정 없음 (v2.1.22 / agents 40 / skills 44 / lib 190 / subdirs 22 / MCP 2)
+- 다음 baseline: **v2.1.191** (다음 분석 v2.1.192부터)


### PR DESCRIPTION
Docs/tooling only — no runtime or version change (stays v2.1.23).

- 7 CC version-impact analysis reports (`docs/04-report/features/cc-v2159..v2191`)
- 7 condensed CC version-history memory notes
- `AGENTS.md` project-rules pointer
- github-stats skill eval (`evals/workflow/github-stats/` + config registration)
- repo traffic stats report (`docs/github-stats-bkit-claude-code.md`)

Branch fast-forwarded onto v2.1.23 main; all contract gates green locally (docs-code-sync, invocation-inventory 210/210, bkit-full-system).