### PR TITLE
fix(qa): repair four silent breaks between the QA agents and the qa gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+> Version heading is provisional — the maintainer assigns the release number.
+
+### Fixed — QA pipeline wiring
+
+Four breaks between the QA agents and the qa quality gate. Each was silent: the
+QA phase printed "QA Phase completed" while the value it exists to produce never
+reached the gate. Found by reading the qa-lead → qa-phase-stop → gate-manager →
+state-machine path end to end rather than from a failing run, because none of
+these can produce a failing run — they produce a run that looks fine.
+
+- **QA metric collection crashed on its first line and swallowed the error.**
+  `readStdinSync()` returns the *parsed* hook payload — an object — and
+  `scripts/qa-phase-stop.js` assigned it to `qaOutput` and called `.match()` on
+  it. TypeError on M11, caught by the handler's own try/catch, and M11–M15 were
+  never written on any run since v2.1.1. Adds `readHookText()` to
+  `lib/core/io.js`, which resolves the payload to the assistant's reported text
+  via `transcript_path` (text blocks only — `thinking` and `tool_use` would
+  produce false metric hits) and always returns a string.
+
+- **The qa gate required a metric that no metric ID produced.** `gate-manager`'s
+  `qa` gate has listed `qaCriticalCount === 0` as a pass condition since v2.1.1,
+  but `METRIC_ID_TO_GATE_NAME` had no entry mapping to that name, and
+  `_evaluateCondition` treats an absent metric as unsatisfied. `passCount <
+  totalPass` therefore held on every run, so the gate could never return `pass`
+  and QA could not advance to Report regardless of test results — `retry` and
+  `fail` both map to `QA_FAIL`. Adds **M16 (QA Critical Count)** and collects it
+  in the qa Stop handler. The gate is unchanged; the missing piece was the
+  metric.
+
+- **The state machine was handed a blank context.** `scripts/unified-stop.js`
+  built its context with `createContext()`, which carries no QA fields at all,
+  so `guardQaPass` and `guardQaMaxRetryReached` both evaluated against
+  `undefined` — QA_PASS could not fire, and neither could the max-retry escape
+  hatch, leaving a feature able to loop `qa → act` indefinitely. The
+  `recordQaResult` action then wrote those blanks back to pdca-status as nulls,
+  erasing measurements. Switches to `loadContext()` (falling back to
+  `createContext`) and extends `loadContext` to hydrate the QA slice, reading
+  quality-metrics first and pdca-status second. Adds
+  `guardrails.loopBreaker.maxQaRetries` to `bkit.config.json` so the retry
+  ceiling is a real, editable setting rather than an inline default.
+
+- **Chrome MCP detection read an environment variable Claude Code never sets.**
+  Both `lib/qa/chrome-bridge.js` and a duplicate copy in
+  `lib/pdca/state-transitions.js` tested `process.env.MCP_SERVERS`, which is
+  always empty under Claude Code, so `chromeAvailable` was false on 100% of runs
+  and L3/L4/L5 were skipped every time — described in qa-lead's own docs as
+  normal fallback, which is how a permanently dark half of the test matrix
+  passed for a feature. Detection is now layered, most authoritative first: a
+  runtime probe qa-lead records in `.bkit/runtime/qa-capabilities.json` (only the
+  agent holds the Chrome MCP tools, so only the agent can observe whether they
+  answer), a `BKIT_CHROME_MCP=1|0` operator override, `MCP_SERVERS` for
+  back-compat, then MCP config files. The duplicate detector now delegates to the
+  bridge instead of drifting alongside it.
+
+Regression coverage: `test/regression/qa-pipeline-wiring.test.js` (23 TC),
+registered in `test/run-all.js`.
+
 ## [2.1.37] - 2026-08-15
 
 > **One-Liner (EN)**: A Claude Code plugin that verifies AI-generated code against its own design specs.

--- a/agents/qa-lead.md
+++ b/agents/qa-lead.md
@@ -63,6 +63,20 @@ Orchestrates QA phase of the PDCA cycle. Runs L1-L5 tests with Chrome MCP integr
 - Task(qa-test-generator): Test Plan + code → Test Code generation
 - Task(qa-debug-analyst): Debug config + error monitoring setup
 
+### Phase 2.5: Record Chrome MCP capability (qa-lead direct)
+
+You hold the Chrome MCP tools; the hooks that later read QA state do not, and no
+environment variable tells them. So before L3, probe once and write the answer
+down — otherwise every downstream reader has to guess, and guessing false is
+what kept L3-L5 permanently skipped:
+
+1. Try one cheap Chrome MCP call (e.g. `tabs_create_mcp`).
+2. Record the outcome via Bash:
+   `node -e "require('${PLUGIN_ROOT}/lib/qa').recordChromeProbe(<true|false>)"`
+
+This writes `.bkit/runtime/qa-capabilities.json`, which `checkChromeAvailable()`
+treats as the authoritative signal.
+
 ### Phase 3: Test Execution (qa-lead direct)
 L1 (Unit): `node --test` or `npx jest` execution (Bash)
 L2 (API): curl/fetch-based API endpoint verification (Bash)

--- a/bkit.config.json
+++ b/bkit.config.json
@@ -195,6 +195,7 @@
     "destructiveDetection": true,
     "loopBreaker": {
       "maxPdcaIterations": 5,
+      "maxQaRetries": 3,
       "maxSameFileEdits": 10,
       "maxAgentRecursion": 3,
       "cooldownMs": 60000

--- a/lib/core/io.js
+++ b/lib/core/io.js
@@ -318,6 +318,87 @@ async function readStdin() {
 }
 
 /**
+ * Extract the assistant text a Stop handler wants to scan for metrics.
+ *
+ * Why this exists: `readStdinSync` returns the *parsed* hook payload — an
+ * object, never a string. Three Stop handlers were treating its return value
+ * as text and calling `.match()` on it, which throws TypeError on the first
+ * pattern and is then swallowed by the handler's own try/catch. The metrics
+ * those handlers exist to collect were never written, and the failure was
+ * invisible because the handler still printed its success message.
+ *
+ * The payload itself never carries the assistant's answer — only
+ * `transcript_path` does. So the text is read from the transcript's trailing
+ * assistant messages. Only `text` blocks are kept: `thinking` is not the
+ * agent's reported result, and `tool_use` blocks are structured input that
+ * would produce false regex hits (a tool argument containing "pass rate: 100%"
+ * is not a measurement).
+ *
+ * Falls back to `JSON.stringify(input)` when no transcript is readable, which
+ * matches what gap-detector-stop.js has always done — a string, so callers can
+ * regex it without crashing, even if it rarely matches.
+ *
+ * @param {*} input - Parsed hook payload (or a string, passed through)
+ * @param {Object} [options]
+ * @param {number} [options.maxMessages=5] - Trailing assistant messages to keep
+ * @returns {string} Text safe to run regex against — never null/undefined
+ */
+function readHookText(input, options = {}) {
+  if (typeof input === 'string') return input;
+  if (!input || typeof input !== 'object') return '';
+
+  const maxMessages = options.maxMessages || 5;
+  const transcriptPath = input.transcript_path || input.transcriptPath;
+
+  if (transcriptPath) {
+    try {
+      const lines = fs.readFileSync(transcriptPath, 'utf8').split('\n');
+      const collected = [];
+
+      for (let i = lines.length - 1; i >= 0 && collected.length < maxMessages; i--) {
+        if (!lines[i]) continue;
+
+        let entry;
+        try {
+          entry = JSON.parse(lines[i]);
+        } catch (_) {
+          continue; // partial write / non-JSON line — skip, don't abort
+        }
+        if (!entry || entry.type !== 'assistant') continue;
+
+        const content = entry.message && entry.message.content;
+        if (typeof content === 'string') {
+          collected.push(content);
+          continue;
+        }
+        if (!Array.isArray(content)) continue;
+
+        const text = content
+          .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+          .map((block) => block.text)
+          .join('\n');
+        if (text) collected.push(text);
+      }
+
+      if (collected.length > 0) {
+        return collected.reverse().join('\n');
+      }
+    } catch (e) {
+      getDebug().debugLog('io', 'readHookText transcript read failed', {
+        transcriptPath,
+        error: e && e.message,
+      });
+    }
+  }
+
+  try {
+    return JSON.stringify(input);
+  } catch (_) {
+    return '';
+  }
+}
+
+/**
  * Hook 입력 파싱
  *
  * H4 fix (audit): absent fields now return null (not '') so callers can
@@ -889,6 +970,7 @@ module.exports = {
   readStdinSync,
   readStdinBounded,
   readStdin,
+  readHookText,
   parseHookInput,
   outputAllow,
   outputBlock,

--- a/lib/pdca/state-machine.js
+++ b/lib/pdca/state-machine.js
@@ -30,6 +30,12 @@ function getPhase() {
   return _phase;
 }
 
+let _metrics = null;
+function getMetrics() {
+  if (!_metrics) { _metrics = require('../quality/metrics-collector'); }
+  return _metrics;
+}
+
 // S3a ENH-344: STATES/EVENTS/TRANSITIONS/GUARDS/ACTIONS extracted to ./state-transitions
 const { STATES, EVENTS, TRANSITIONS, GUARDS, ACTIONS } = require('./state-transitions');
 
@@ -319,6 +325,55 @@ function loadContext(feature) {
     workflowId: featureData.workflowId || 'default-pdca',
     timestamps: featureData.timestamps || {},
     metadata: featureData.metadata || {},
+    ..._loadQaContext(feature, featureData, getConfig),
+  };
+}
+
+/**
+ * Hydrate the QA slice of a StateMachineContext.
+ *
+ * The qa guards (`guardQaPass`, `guardQaMaxRetryReached`) read ctx.qaPassRate /
+ * ctx.qaCriticalCount / ctx.qaRetryCount, and no context builder ever supplied
+ * them. Every qa guard therefore evaluated against `undefined`: QA_PASS could
+ * not fire, and the max-retry escape hatch could not fire either, leaving a
+ * feature able to loop qa -> act indefinitely. `recordQaResult` then wrote the
+ * same undefined values back to pdca-status as nulls, erasing whatever had been
+ * measured.
+ *
+ * quality-metrics.json is the authoritative source — that is where the qa Stop
+ * handler writes M11/M14/M16 — so it is read first and pdca-status is the
+ * fallback for runs recorded before the metric existed.
+ *
+ * @param {string} feature
+ * @param {Object} featureData - pdca-status entry for the feature
+ * @param {function} getConfig
+ * @returns {Object} QA context slice
+ * @private
+ */
+function _loadQaContext(feature, featureData, getConfig) {
+  let gateMetrics = null;
+  try {
+    gateMetrics = getMetrics().toGateFormat(feature);
+  } catch (_) {
+    // metrics file missing/unreadable — fall back to pdca-status alone
+  }
+  const m = gateMetrics || {};
+
+  const pick = (...vals) => {
+    for (const v of vals) {
+      if (v != null) return v;
+    }
+    return null;
+  };
+
+  return {
+    qaPassRate: pick(m.qaPassRate, featureData.qaPassRate),
+    qaCriticalCount: pick(m.qaCriticalCount, featureData.qaCriticalCount),
+    qaRetryCount: featureData.qaRetryCount || 0,
+    maxQaRetries: getConfig('guardrails.loopBreaker.maxQaRetries', 3),
+    chromeAvailable: featureData.chromeAvailable != null
+      ? featureData.chromeAvailable
+      : null,
   };
 }
 

--- a/lib/pdca/state-transitions.js
+++ b/lib/pdca/state-transitions.js
@@ -50,13 +50,19 @@ function getPhase() {
 // ── Chrome MCP Availability Helper ──────────────────────────────────
 
 /**
- * Check Chrome MCP availability
+ * Check Chrome MCP availability.
+ *
+ * This used to be a second, independent copy of the `MCP_SERVERS` check that
+ * lib/qa/chrome-bridge.js also carried — two detectors that had to be fixed in
+ * two places and could disagree. It now delegates to the bridge, which is the
+ * module that owns the question. Lazy-required so a bridge load failure cannot
+ * break the state machine at import time.
+ *
  * @returns {boolean}
  */
 function _checkChromeMcpAvailable() {
   try {
-    const mcpServers = process.env.MCP_SERVERS || '';
-    return mcpServers.includes('claude-in-chrome');
+    return require('../qa/chrome-bridge').checkChromeAvailable().available;
   } catch (_) {
     return false;
   }

--- a/lib/qa/chrome-bridge.js
+++ b/lib/qa/chrome-bridge.js
@@ -7,51 +7,174 @@
  * Used by qa-lead agent for L3-L5 test execution.
  */
 
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
 let _core = null;
 function getCore() {
   if (!_core) { _core = require('../core'); }
   return _core;
 }
 
+/** Chrome MCP tool names exposed to qa-lead for L3-L5. */
+const CHROME_MCP_TOOLS = [
+  'tabs_create_mcp', 'navigate', 'form_input', 'find',
+  'get_page_text', 'read_console_messages', 'read_network_requests',
+  'gif_creator',
+];
+
+/** Server-name fragment that identifies the Chrome MCP server. */
+const CHROME_SERVER_HINT = 'claude-in-chrome';
+
 /**
  * @typedef {Object} ChromeAvailability
  * @property {boolean} available - Chrome MCP is accessible
  * @property {string} reason - Availability reason
  * @property {string[]} tools - Available Chrome MCP tool names
+ * @property {string} source - Which detection strategy decided the answer
  */
 
+function _projectDir() {
+  return process.env.CLAUDE_PROJECT_DIR || process.cwd();
+}
+
+function _readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (_) {
+    return null;
+  }
+}
+
 /**
- * Check Chrome MCP availability
- * Detection strategy:
- * 1. MCP_SERVERS env var includes 'claude-in-chrome'
+ * Look for a Chrome MCP server registration in the files that declare MCP
+ * servers. Config presence means "configured", not "connected" — it is weaker
+ * evidence than the runtime probe, which is why it is checked last.
+ * @returns {boolean}
+ * @private
+ */
+function _configDeclaresChrome() {
+  const root = _projectDir();
+  const candidates = [
+    path.join(root, '.mcp.json'),
+    path.join(root, '.claude', 'settings.json'),
+    path.join(root, '.claude', 'settings.local.json'),
+    path.join(os.homedir(), '.claude.json'),
+    path.join(os.homedir(), '.claude', 'settings.json'),
+  ];
+
+  for (const file of candidates) {
+    const json = _readJson(file);
+    if (!json) continue;
+
+    const names = [
+      ...Object.keys(json.mcpServers || {}),
+      ...(Array.isArray(json.enabledMcpjsonServers) ? json.enabledMcpjsonServers : []),
+    ];
+    if (names.some((n) => String(n).includes(CHROME_SERVER_HINT))) return true;
+
+    // ~/.claude.json nests per-project overrides one level down.
+    const projects = json.projects && typeof json.projects === 'object' ? json.projects : {};
+    for (const entry of Object.values(projects)) {
+      const nested = Object.keys((entry && entry.mcpServers) || {});
+      if (nested.some((n) => String(n).includes(CHROME_SERVER_HINT))) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check Chrome MCP availability.
+ *
+ * Detection used to be a single line — `process.env.MCP_SERVERS` — and Claude
+ * Code does not set that variable. It was therefore false on every run, so
+ * L3/L4/L5 were skipped 100% of the time even with Chrome MCP connected, and
+ * qa-lead's own docs described that skip as normal fallback, which made a
+ * permanently-dark half of the test matrix look like a feature.
+ *
+ * Strategies, most authoritative first:
+ *   1. Runtime probe recorded by qa-lead in `.bkit/runtime/qa-capabilities.json`.
+ *      Only the agent holds the Chrome MCP tools, so only the agent can observe
+ *      whether they actually answer. A hook process cannot.
+ *   2. `BKIT_CHROME_MCP=1|0` — explicit operator override, both directions.
+ *   3. `MCP_SERVERS` env (kept for back-compat with any harness that sets it).
+ *   4. MCP config files declaring a `claude-in-chrome` server.
  *
  * @returns {ChromeAvailability}
  */
 function checkChromeAvailable() {
   const { debugLog } = getCore();
 
-  // Strategy 1: Environment variable
-  const mcpServers = process.env.MCP_SERVERS || '';
-  if (mcpServers.includes('claude-in-chrome')) {
-    debugLog('QA-Chrome', 'Chrome MCP detected via MCP_SERVERS');
-    return {
-      available: true,
-      reason: 'Chrome MCP detected via MCP_SERVERS environment',
-      tools: [
-        'tabs_create_mcp', 'navigate', 'form_input', 'find',
-        'get_page_text', 'read_console_messages', 'read_network_requests',
-        'gif_creator',
-      ],
-    };
+  const decide = (available, reason, source) => {
+    debugLog('QA-Chrome', available ? 'Chrome MCP available' : 'Chrome MCP not available',
+      { reason, source });
+    return { available, reason, source, tools: available ? CHROME_MCP_TOOLS : [] };
+  };
+
+  // Strategy 1: runtime probe written by qa-lead (ground truth)
+  const cap = _readJson(path.join(_projectDir(), '.bkit', 'runtime', 'qa-capabilities.json'));
+  if (cap && cap.chromeMcp && typeof cap.chromeMcp.available === 'boolean') {
+    return decide(
+      cap.chromeMcp.available,
+      `Runtime probe by qa-lead at ${cap.chromeMcp.checkedAt || 'unknown time'}`,
+      'runtime-probe'
+    );
   }
 
-  // Not found
-  debugLog('QA-Chrome', 'Chrome MCP not available');
-  return {
-    available: false,
-    reason: 'Chrome MCP (claude-in-chrome) not found in MCP_SERVERS',
-    tools: [],
-  };
+  // Strategy 2: explicit override
+  const override = (process.env.BKIT_CHROME_MCP || '').trim().toLowerCase();
+  if (override === '1' || override === 'true') {
+    return decide(true, 'BKIT_CHROME_MCP override set to on', 'env-override');
+  }
+  if (override === '0' || override === 'false') {
+    return decide(false, 'BKIT_CHROME_MCP override set to off', 'env-override');
+  }
+
+  // Strategy 3: MCP_SERVERS env (back-compat)
+  if ((process.env.MCP_SERVERS || '').includes(CHROME_SERVER_HINT)) {
+    return decide(true, 'Chrome MCP detected via MCP_SERVERS environment', 'env-mcp-servers');
+  }
+
+  // Strategy 4: MCP config files
+  if (_configDeclaresChrome()) {
+    return decide(true, 'Chrome MCP server declared in MCP configuration', 'mcp-config');
+  }
+
+  return decide(
+    false,
+    'Chrome MCP (claude-in-chrome) not found via runtime probe, override, environment, or MCP config',
+    'none'
+  );
+}
+
+/**
+ * Record the result of a live Chrome MCP probe.
+ *
+ * qa-lead calls this (or writes the same file) once it has actually tried a
+ * Chrome MCP tool, turning a guess into an observation for every later reader.
+ *
+ * @param {boolean} available - Whether Chrome MCP tools responded
+ * @param {Object} [details] - Optional extra context to persist
+ * @returns {boolean} Whether the capability file was written
+ */
+function recordChromeProbe(available, details = {}) {
+  const { debugLog } = getCore();
+  const file = path.join(_projectDir(), '.bkit', 'runtime', 'qa-capabilities.json');
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const current = _readJson(file) || {};
+    current.chromeMcp = {
+      available: !!available,
+      checkedAt: new Date().toISOString(),
+      ...details,
+    };
+    fs.writeFileSync(file, JSON.stringify(current, null, 2));
+    return true;
+  } catch (e) {
+    debugLog('QA-Chrome', 'Failed to record Chrome probe', { error: e && e.message });
+    return false;
+  }
 }
 
 /**
@@ -100,6 +223,8 @@ function createChromeBridge() {
 }
 
 module.exports = {
+  CHROME_MCP_TOOLS,
   checkChromeAvailable,
+  recordChromeProbe,
   createChromeBridge,
 };

--- a/lib/qa/index.js
+++ b/lib/qa/index.js
@@ -85,6 +85,7 @@ module.exports = {
 
   // Chrome Bridge
   checkChromeAvailable: chromeBridge.checkChromeAvailable,
+  recordChromeProbe: chromeBridge.recordChromeProbe,
   createChromeBridge: chromeBridge.createChromeBridge,
 
   // Report Generator

--- a/lib/quality/metrics-collector.js
+++ b/lib/quality/metrics-collector.js
@@ -1,5 +1,5 @@
 /**
- * Quality Metrics Collector - 10 Quality Metrics (M1-M10)
+ * Quality Metrics Collector - 16 Quality Metrics (M1-M16)
  * @module lib/quality/metrics-collector
  * @version 2.1.10
  *
@@ -16,12 +16,12 @@ const { STATE_PATHS } = require('../core/paths');
 const { MAX_QUALITY_HISTORY } = require('../core/constants');
 
 // ============================================================
-// Metric Specifications (M1-M10)
+// Metric Specifications (M1-M16)
 // ============================================================
 
 /**
  * @typedef {Object} MetricSpec
- * @property {string} id - Metric identifier (M1-M10)
+ * @property {string} id - Metric identifier (M1-M16)
  * @property {string} name - Human-readable metric name
  * @property {string} collector - Agent/source that collects this metric
  * @property {string} unit - Unit of measurement (%, count, 0-100, ms, hours, %p/iteration)
@@ -47,6 +47,18 @@ const METRIC_SPECS = {
   M13: { id: 'M13', name: 'E2E Scenario Coverage', collector: 'qa-lead', unit: '%', direction: 'higher' },
   M14: { id: 'M14', name: 'Runtime Error Count', collector: 'qa-debug-analyst', unit: 'count', direction: 'lower' },
   M15: { id: 'M15', name: 'Data Flow Integrity', collector: 'qa-lead', unit: '%', direction: 'higher' },
+
+  /*
+   * M16 — the gate's second QA pass condition had no metric behind it.
+   *
+   * gate-manager's `qa` gate has required `qaCriticalCount === 0` since v2.1.1,
+   * but no M-ID ever mapped to that name, so `toGateFormat` could not produce
+   * the key. `_evaluateCondition` treats an absent metric as not satisfied, so
+   * `passCount < totalPass` held on every run and the qa gate could never
+   * return 'pass' — QA was structurally unable to advance to Report regardless
+   * of how the tests actually went. The metric, not the gate, was missing.
+   */
+  M16: { id: 'M16', name: 'QA Critical Count', collector: 'qa-lead', unit: 'count', direction: 'lower' },
 };
 
 // ============================================================
@@ -54,7 +66,7 @@ const METRIC_SPECS = {
 // ============================================================
 
 /**
- * Mapping from metric ID (M1-M10) to gate-manager metric names.
+ * Mapping from metric ID (M1-M16) to gate-manager metric names.
  * gate-manager uses these keys in GATE_DEFINITIONS conditions.
  * @type {Record<string, string>}
  */
@@ -74,6 +86,7 @@ const METRIC_ID_TO_GATE_NAME = {
   M13: 'e2eScenarioCoverage',
   M14: 'runtimeErrorCount',
   M15: 'dataFlowIntegrity',
+  M16: 'qaCriticalCount',
 };
 
 /** @type {Record<string, string>} */
@@ -82,7 +95,7 @@ const GATE_NAME_TO_METRIC_ID = Object.fromEntries(
 );
 
 /**
- * Convert collected metrics (keyed by M1-M10) to gate-manager format
+ * Convert collected metrics (keyed by M1-M16) to gate-manager format
  * (keyed by friendly names like matchRate, codeQualityScore).
  *
  * @param {string} feature - Feature name
@@ -160,7 +173,7 @@ function _historyPath() {
  * Collect a single metric value.
  * Updates the current metrics snapshot for the feature.
  *
- * @param {string} metricId - Metric identifier (M1-M10)
+ * @param {string} metricId - Metric identifier (M1-M16)
  * @param {string} feature - Feature name
  * @param {number} value - Measured value
  * @param {string} [collector] - Override collector name (defaults to spec)

--- a/scripts/qa-phase-stop.js
+++ b/scripts/qa-phase-stop.js
@@ -2,12 +2,12 @@
 /**
  * qa-phase-stop.js - QA Phase Stop Event Handler
  *
- * Collects M11-M15 metrics from QA execution results
+ * Collects M11-M16 metrics from QA execution results
  * and triggers appropriate state machine event (QA_PASS/QA_FAIL/QA_SKIP).
  */
 
 const path = require('path');
-const { readStdinSync, outputAllow } = require('../lib/core/io');
+const { readStdinSync, readHookText, outputAllow } = require('../lib/core/io');
 const { debugLog } = require('../lib/core/debug');
 // C7/C8/L2 (audit): atomic+locked reachability ping + single BKIT_VERSION source.
 // L2: this hook was the only Stop/Post handler without a reachability stamp.
@@ -24,9 +24,18 @@ try {
   const currentStatus = getPdcaStatusFull();
   const feature = extractFeatureFromContext({ currentStatus }) || 'unknown';
 
-  // Read QA phase output from stdin
+  /*
+   * Read the QA output as TEXT.
+   *
+   * `readStdinSync()` returns the parsed hook payload — an object. The previous
+   * code assigned it straight to `qaOutput` and called `.match()` on it, which
+   * throws TypeError on the very first pattern below. The outer catch swallowed
+   * it, so none of M11-M15 was ever collected while the handler still reported
+   * success. readHookText normalizes the payload to the assistant's actual
+   * reported text (via transcript_path) and always returns a string.
+   */
   let qaOutput = '';
-  try { qaOutput = readStdinSync() || ''; } catch (_) {}
+  try { qaOutput = readHookText(readStdinSync()); } catch (_) { qaOutput = ''; }
 
   // M11: QA Pass Rate
   const passRateMatch = qaOutput.match(/pass\s*rate[^0-9]*(\d+\.?\d*)\s*%/i);
@@ -53,8 +62,23 @@ try {
   const dataFlowIntegrity = integrityMatch ? parseFloat(integrityMatch[1]) : 100;
   mc.collectMetric('M15', feature, dataFlowIntegrity, 'qa-lead');
 
+  /*
+   * M16: QA Critical Count — the gate has required this since v2.1.1 but
+   * nothing ever produced it (see METRIC_SPECS.M16). qa-lead's Phase 4 reports
+   * it alongside passRate, so it is parsed from the same text.
+   *
+   * Absent means zero, matching M14's existing convention: "no criticals
+   * reported" is the normal shape of a clean run. This is safe because a run
+   * whose output cannot be parsed at all also yields qaPassRate 0, which fails
+   * the gate on its own — M16 defaulting to 0 cannot turn a broken run green.
+   */
+  const criticalMatch = qaOutput.match(/critical[^0-9]{0,20}(\d+)/i);
+  const qaCriticalCount = criticalMatch ? parseInt(criticalMatch[1], 10) : 0;
+  mc.collectMetric('M16', feature, qaCriticalCount, 'qa-lead');
+
   debugLog('QA-Phase-Stop', 'Metrics collected', {
-    feature, qaPassRate, testCoverage, e2eCoverage, runtimeErrors, dataFlowIntegrity
+    feature, qaPassRate, testCoverage, e2eCoverage, runtimeErrors, dataFlowIntegrity,
+    qaCriticalCount
   });
 } catch (e) {
   debugLog('QA-Phase-Stop', 'Metric collection failed', { error: e.message });

--- a/scripts/unified-stop.js
+++ b/scripts/unified-stop.js
@@ -392,7 +392,18 @@ if (feature && currentPhase) {
   try {
     const sm = getStateMachine();
     if (sm) {
-      const ctx = sm.createContext(feature);
+      /*
+       * loadContext, not createContext.
+       *
+       * createContext returns a blank context — matchRate 0, no qa fields at
+       * all — so every guard downstream evaluated against values this session
+       * had never measured. guardQaPass could not pass, guardQaMaxRetryReached
+       * could not release the qa -> act loop, and the recordQaResult action
+       * wrote the blanks back over real measurements. loadContext hydrates from
+       * pdca-status and quality-metrics; createContext stays as the fallback
+       * for a feature with no status entry yet.
+       */
+      const ctx = sm.loadContext(feature) || sm.createContext(feature);
 
       // Determine FSM event based on gate verdict + phase
       let event = null;

--- a/test/regression/qa-pipeline-wiring.test.js
+++ b/test/regression/qa-pipeline-wiring.test.js
@@ -1,0 +1,194 @@
+'use strict';
+/**
+ * Regression tests for the QA pipeline wiring defects.
+ * 18 TC | console.assert based | no external dependencies
+ *
+ * Each defect below was silent: the QA phase reported success while the value
+ * it exists to produce never reached the gate. These tests pin the four repairs
+ * so a future refactor cannot quietly restore the dark path.
+ *
+ *   C-1  readStdinSync returns an object; qa-phase-stop called .match() on it,
+ *        threw TypeError, and swallowed it — M11-M15 never collected.
+ *   C-2  the qa gate required qaCriticalCount, which no metric ID produced, so
+ *        the gate could never return 'pass'.
+ *   C-3  unified-stop built a blank context, so every qa guard evaluated
+ *        against undefined and recordQaResult wrote nulls over measurements.
+ *   H-1  Chrome detection read MCP_SERVERS, which Claude Code never sets, so
+ *        L3-L5 were skipped on 100% of runs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bkit-qa-wiring-'));
+fs.mkdirSync(path.join(tmpDir, '.bkit', 'state'), { recursive: true });
+
+// Point every path-aware module at the sandbox.
+const platformPath = require.resolve('../../lib/core/platform');
+const origPlatform = require(platformPath);
+require.cache[platformPath] = {
+  id: platformPath,
+  filename: platformPath,
+  loaded: true,
+  exports: { ...origPlatform, PROJECT_DIR: tmpDir },
+};
+const origProjectDirEnv = process.env.CLAUDE_PROJECT_DIR;
+const origChromeEnv = process.env.BKIT_CHROME_MCP;
+const origMcpServersEnv = process.env.MCP_SERVERS;
+process.env.CLAUDE_PROJECT_DIR = tmpDir;
+delete process.env.BKIT_CHROME_MCP;
+delete process.env.MCP_SERVERS;
+
+const io = require('../../lib/core/io');
+const mc = require('../../lib/quality/metrics-collector');
+const gates = require('../../lib/quality/gate-manager');
+const sm = require('../../lib/pdca/state-machine');
+const chrome = require('../../lib/qa/chrome-bridge');
+
+let passed = 0, failed = 0, total = 0, skipped = 0;
+const failures = [];
+
+function assert(id, condition, message) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${id} - ${message}`); }
+  else { failed++; failures.push({ id, message }); console.error(`  FAIL: ${id} - ${message}`); }
+}
+
+console.log('\n=== qa-pipeline-wiring.test.js ===\n');
+
+// --- C-1: readHookText always yields regex-safe text ---
+
+assert('QW-001', typeof io.readHookText === 'function', 'readHookText is exported');
+assert('QW-002', typeof io.readHookText({ session_id: 'x' }) === 'string',
+  'Object payload returns a string, not the object');
+assert('QW-003', typeof io.readHookText(null) === 'string', 'null payload returns a string');
+assert('QW-004', typeof io.readHookText(undefined) === 'string', 'undefined payload returns a string');
+assert('QW-005', io.readHookText('already text') === 'already text', 'String payload passes through');
+
+// The original crash, reproduced: .match() on whatever the helper returns must
+// not throw for any payload shape a hook can receive.
+let matchThrew = false;
+try {
+  io.readHookText({ hook_event_name: 'Stop' }).match(/pass\s*rate[^0-9]*(\d+)/i);
+} catch (_) {
+  matchThrew = true;
+}
+assert('QW-006', !matchThrew, '.match() on the result never throws (the C-1 crash)');
+
+// Transcript extraction: assistant text only — thinking and tool_use blocks are
+// not reported results and would produce false metric hits.
+const transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+fs.writeFileSync(transcriptPath, [
+  JSON.stringify({ type: 'user', message: { content: 'run qa' } }),
+  JSON.stringify({
+    type: 'assistant',
+    message: { content: [
+      { type: 'thinking', thinking: 'Pass Rate: 11%' },
+      { type: 'tool_use', name: 'Bash', input: { command: 'echo "Pass Rate: 22%"' } },
+      { type: 'text', text: 'QA complete. Pass Rate: 97.5% — Critical: 0' },
+    ] },
+  }),
+  '',
+].join('\n'));
+
+const text = io.readHookText({ transcript_path: transcriptPath });
+assert('QW-007', text.includes('Pass Rate: 97.5%'), 'Assistant text block is extracted');
+assert('QW-008', !text.includes('11%'), 'thinking block is excluded');
+assert('QW-009', !text.includes('22%'), 'tool_use block is excluded');
+assert('QW-010', io.readHookText({ transcript_path: '/nonexistent/x.jsonl' }).length > 0,
+  'Unreadable transcript falls back to a string instead of throwing');
+
+// --- C-2: qaCriticalCount has a metric behind it, so the qa gate can pass ---
+
+assert('QW-011', mc.METRIC_SPECS.M16 !== undefined, 'M16 metric spec exists');
+assert('QW-012', mc.METRIC_ID_TO_GATE_NAME.M16 === 'qaCriticalCount',
+  'M16 maps to the gate metric name qaCriticalCount');
+assert('QW-013', mc.GATE_NAME_TO_METRIC_ID.qaCriticalCount === 'M16',
+  'Inverse mapping resolves qaCriticalCount');
+
+const FEATURE = 'qa-wiring-feature';
+mc.collectMetric('M11', FEATURE, 100, 'qa-lead');          // qaPassRate
+mc.collectMetric('M14', FEATURE, 0, 'qa-debug-analyst');   // runtimeErrorCount
+mc.collectMetric('M16', FEATURE, 0, 'qa-lead');            // qaCriticalCount
+
+const gateMetrics = mc.toGateFormat(FEATURE);
+assert('QW-014', gateMetrics && gateMetrics.qaCriticalCount === 0,
+  'toGateFormat emits qaCriticalCount');
+
+const clean = gates.checkGate('qa', {
+  feature: FEATURE,
+  projectLevel: 'Dynamic',
+  metrics: gateMetrics,
+});
+assert('QW-015', clean.verdict === 'pass',
+  'A clean QA run now reaches verdict pass (was structurally impossible)');
+
+// Every pass condition must still be enforced — the fix supplies the metric,
+// it does not weaken the gate.
+const dirty = gates.checkGate('qa', {
+  feature: FEATURE,
+  projectLevel: 'Dynamic',
+  metrics: { ...gateMetrics, qaCriticalCount: 2 },
+});
+assert('QW-016', dirty.verdict === 'fail', 'A critical failure still blocks the qa gate');
+
+// --- C-3: loadContext hydrates the QA slice the guards read ---
+
+// unified-stop only reaches the state machine for a feature that already has a
+// pdca-status entry (that is where it reads the feature name from), so the
+// fixture mirrors that: status entry present, measurements in quality-metrics.
+// requireDocs:false — the L3 doc gate is not what is under test here.
+require('../../lib/pdca/status')
+  .updatePdcaStatus(FEATURE, 'qa', { qaRetryCount: 1 }, { requireDocs: false });
+
+const ctx = sm.loadContext(FEATURE) || sm.createContext(FEATURE);
+assert('QW-017', ctx.qaPassRate === 100 && ctx.qaCriticalCount === 0,
+  'loadContext hydrates qaPassRate/qaCriticalCount from collected metrics');
+assert('QW-018', typeof ctx.maxQaRetries === 'number' && ctx.maxQaRetries > 0,
+  'loadContext supplies maxQaRetries so the retry escape hatch can fire');
+
+// --- H-1: Chrome detection no longer depends on an env var CC never sets ---
+
+const noSignal = chrome.checkChromeAvailable();
+assert('QW-019', noSignal.available === false && noSignal.source === 'none',
+  'No signal present reports unavailable with an explicit source');
+
+process.env.BKIT_CHROME_MCP = '1';
+assert('QW-020', chrome.checkChromeAvailable().available === true,
+  'BKIT_CHROME_MCP=1 override turns detection on');
+process.env.BKIT_CHROME_MCP = '0';
+assert('QW-021', chrome.checkChromeAvailable().available === false,
+  'BKIT_CHROME_MCP=0 override turns detection off');
+delete process.env.BKIT_CHROME_MCP;
+
+chrome.recordChromeProbe(true, { probedWith: 'tabs_create_mcp' });
+const probed = chrome.checkChromeAvailable();
+assert('QW-022', probed.available === true && probed.source === 'runtime-probe',
+  'A recorded runtime probe is the authoritative signal');
+
+// The probe outranks a stale negative environment, which is the whole point:
+// only the agent can observe whether Chrome MCP actually answers.
+process.env.MCP_SERVERS = '';
+assert('QW-023', chrome.checkChromeAvailable().available === true,
+  'Runtime probe wins over an empty MCP_SERVERS environment');
+delete process.env.MCP_SERVERS;
+
+// --- Cleanup ---
+delete require.cache[platformPath];
+if (origProjectDirEnv === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+else process.env.CLAUDE_PROJECT_DIR = origProjectDirEnv;
+if (origChromeEnv === undefined) delete process.env.BKIT_CHROME_MCP;
+else process.env.BKIT_CHROME_MCP = origChromeEnv;
+if (origMcpServersEnv === undefined) delete process.env.MCP_SERVERS;
+else process.env.MCP_SERVERS = origMcpServersEnv;
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+// --- Summary ---
+console.log(`\nResults: ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`);
+if (failures.length > 0) {
+  console.log('Failures:');
+  failures.forEach(f => console.log(`  - ${f.id}: ${f.message}`));
+}
+
+module.exports = { passed, failed, total, skipped, failures };

--- a/test/run-all.js
+++ b/test/run-all.js
@@ -326,8 +326,10 @@ const CATEGORIES = {
       'regression/gap-detector-unmeasured.test.js',
       // v2.1.37: permission-mode awareness + the five defects coupled to it.
       'regression/enh-466-473-permission-mode.test.js',
+      // QA pipeline wiring — four silent breaks between qa-lead and the qa gate.
+      'regression/qa-pipeline-wiring.test.js',
     ],
-    expected: 610,
+    expected: 633,
   },
   performance: {
     name: 'Performance Tests',

--- a/test/unit/metrics-collector-full.test.js
+++ b/test/unit/metrics-collector-full.test.js
@@ -24,12 +24,13 @@ test('MC-01', 'METRIC_SPECS contains M1-M10 metric definitions', () => {
   }
 });
 
-// TC-02: METRIC_ID_TO_GATE_NAME maps M1-M10 to gate names
-test('MC-02', 'METRIC_ID_TO_GATE_NAME maps all 10 metric IDs', () => {
+// TC-02: METRIC_ID_TO_GATE_NAME maps M1-M16 to gate names
+test('MC-02', 'METRIC_ID_TO_GATE_NAME maps all 16 metric IDs', () => {
   assert.ok(mc.METRIC_ID_TO_GATE_NAME && typeof mc.METRIC_ID_TO_GATE_NAME === 'object');
-  assert.strictEqual(Object.keys(mc.METRIC_ID_TO_GATE_NAME).length, 15, 'Must have 15 entries (M1-M15)');
+  assert.strictEqual(Object.keys(mc.METRIC_ID_TO_GATE_NAME).length, 16, 'Must have 16 entries (M1-M16)');
   assert.strictEqual(mc.METRIC_ID_TO_GATE_NAME.M1, 'matchRate');
   assert.strictEqual(mc.METRIC_ID_TO_GATE_NAME.M10, 'pdcaCycleTimeHours');
+  assert.strictEqual(mc.METRIC_ID_TO_GATE_NAME.M16, 'qaCriticalCount');
 });
 
 // TC-03: GATE_NAME_TO_METRIC_ID is the inverse mapping


### PR DESCRIPTION
## What this is

Four defects on the path from the QA agents to the `qa` quality gate. They share a shape: **the QA phase prints "QA Phase completed" while the value it exists to produce never reaches the gate.** None of them can produce a failing run, so none of them show up in a test report — they were found by reading `qa-lead` → `qa-phase-stop` → `gate-manager` → `state-machine` end to end.

Verified present on `main` @ v2.1.37.

## The four

### C-1 — QA metric collection crashes on its first line, and the error is swallowed

`scripts/qa-phase-stop.js:29`

```js
qaOutput = readStdinSync() || '';              // returns the PARSED payload — an object
const passRateMatch = qaOutput.match(/.../i);  // TypeError
```

`readStdinSync` (`lib/core/io.js`) returns `JSON.parse(...)` — an object, and `{}` even on failure. `.match` throws on M11, the handler's own outer `try/catch` catches it, and **M11–M15 have never been written on any run since v2.1.1.** The handler still prints its success message, so nothing looks wrong.

Fix: `io.readHookText()` resolves the payload to the assistant's reported text via `transcript_path` and always returns a string. Only `text` blocks are kept — `thinking` isn't a reported result, and a `tool_use` argument containing `"pass rate: 100%"` is not a measurement.

### C-2 — the `qa` gate requires a metric that no metric ID produces

`lib/quality/gate-manager.js:108-112` has required `qaCriticalCount === 0` since v2.1.1. `METRIC_ID_TO_GATE_NAME` has no entry mapping to that name, and `_evaluateCondition` returns `false` for an absent metric. So `passCount < totalPass` holds on **every** run and the gate can never return `pass`; `unified-stop` maps both `retry` and `fail` to `QA_FAIL`. **QA was structurally unable to advance to Report regardless of test results.**

Fix: add **M16 (QA Critical Count)** and collect it. The gate is untouched — the metric was what was missing, not the threshold.

### C-3 — the state machine is handed a blank context

`scripts/unified-stop.js` built its context with `createContext()`, which carries no QA fields at all. Consequences:

| | |
|---|---|
| `guardQaPass` evaluates `undefined` | QA_PASS can never fire |
| `guardQaMaxRetryReached` evaluates `undefined` | max-retry escape hatch never fires → `qa → act` can loop indefinitely |
| `recordQaResult` writes the blanks back | real measurements overwritten with `null` |

Fix: `loadContext()` with `createContext` as fallback, and `loadContext` now hydrates the QA slice — quality-metrics first (where the Stop handler writes), pdca-status second. Adds `guardrails.loopBreaker.maxQaRetries` to `bkit.config.json` so the retry ceiling is a real setting rather than an inline default (same class of drift as ENH-453).

### H-1 — Chrome MCP detection reads an env var Claude Code never sets

`process.env.MCP_SERVERS`, checked in two independent copies (`lib/qa/chrome-bridge.js` and a duplicate in `lib/pdca/state-transitions.js`). It is always empty under Claude Code, so `chromeAvailable` is false on 100% of runs and **L3/L4/L5 are skipped every time** — while `qa-lead.md` describes that skip as normal fallback. A permanently dark half of the test matrix reads as a feature.

Fix: layered detection, most authoritative first —

1. runtime probe recorded by qa-lead in `.bkit/runtime/qa-capabilities.json`. Only the agent holds the Chrome MCP tools, so only the agent can observe whether they answer; a hook process cannot.
2. `BKIT_CHROME_MCP=1|0` operator override (both directions).
3. `MCP_SERVERS` — kept for back-compat.
4. MCP config files declaring a `claude-in-chrome` server.

The duplicate detector now delegates to the bridge instead of drifting alongside it.

## Verification

- New: `test/regression/qa-pipeline-wiring.test.js` — **23 TC, all passing**, registered in `test/run-all.js`. Includes the exact C-1 crash as a test, and asserts the gate still **fails** on a real critical (QW-016) so C-2 reads as "supply the metric", not "weaken the gate".
- `--unit` 1953/1954 (1 skip), `--integration` 609/609, `--architecture` 100/100, `--philosophy` 140/140, `--security` 267/267, `--regression` 819/819, `--behavioral` 45/45.
- `--contract` has 1 failure (`SSK-LIVE / primaryFeature`) — **pre-existing**, reproduced on a clean checkout of `main`, unrelated to this change.
- eslint on touched files: errors 18 → 17, +4 `catch (_)` warnings matching the repo's existing idiom.
- `.claude-plugin/plugin.json` version **not** touched, per the repo's versioning rule. The CHANGELOG entry is under `## [Unreleased]` with the heading marked provisional.

## Notes for the maintainer

Related findings left out of this PR to keep it reviewable — happy to file separately:

- `scripts/analysis-stop.js` and `scripts/qa-stop.js` `require` `readStdinSync` but never call it; they regex the handler's own hardcoded guidance string, so M2 is always the 75 default and M5 always 0. `readHookText` is the fix, same as C-1.
- `QA_RETRY` (`act → qa`) is defined but never emitted by anything, so `initQaPhase` — the only action attached to it — never runs on re-entry.
- `qa-lead` declares `Task(qa-monitor)` and its description claims it coordinates four agents, but the Orchestration Protocol never dispatches qa-monitor.
- `qa-lead` Phase 2 runs planner and generator concurrently, though the generator's input is the planner's Test Plan.
- `skills/qa-phase/SKILL.md` tells the user to run `scripts/qa/pre-release-check.sh` by relative path; the file only exists inside the plugin, and the script's own `PROJECT_ROOT` resolves to the plugin, so it scans bkit rather than the user's project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
