### PR TITLE
fix(qa): deliver the hook payload to Stop handlers, and close five QA gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+> Version heading is provisional — the maintainer assigns the release number.
+
+### Fixed — QA pipeline wiring
+
+Four breaks between the QA agents and the qa quality gate. Each was silent: the
+QA phase printed "QA Phase completed" while the value it exists to produce never
+reached the gate. Found by reading the qa-lead → qa-phase-stop → gate-manager →
+state-machine path end to end rather than from a failing run, because none of
+these can produce a failing run — they produce a run that looks fine.
+
+- **QA metric collection crashed on its first line and swallowed the error.**
+  `readStdinSync()` returns the *parsed* hook payload — an object — and
+  `scripts/qa-phase-stop.js` assigned it to `qaOutput` and called `.match()` on
+  it. TypeError on M11, caught by the handler's own try/catch, and M11–M15 were
+  never written on any run since v2.1.1. Adds `readHookText()` to
+  `lib/core/io.js`, which resolves the payload to the assistant's reported text
+  via `transcript_path` (text blocks only — `thinking` and `tool_use` would
+  produce false metric hits) and always returns a string.
+
+- **The qa gate required a metric that no metric ID produced.** `gate-manager`'s
+  `qa` gate has listed `qaCriticalCount === 0` as a pass condition since v2.1.1,
+  but `METRIC_ID_TO_GATE_NAME` had no entry mapping to that name, and
+  `_evaluateCondition` treats an absent metric as unsatisfied. `passCount <
+  totalPass` therefore held on every run, so the gate could never return `pass`
+  and QA could not advance to Report regardless of test results — `retry` and
+  `fail` both map to `QA_FAIL`. Adds **M16 (QA Critical Count)** and collects it
+  in the qa Stop handler. The gate is unchanged; the missing piece was the
+  metric.
+
+- **The state machine was handed a blank context.** `scripts/unified-stop.js`
+  built its context with `createContext()`, which carries no QA fields at all,
+  so `guardQaPass` and `guardQaMaxRetryReached` both evaluated against
+  `undefined` — QA_PASS could not fire, and neither could the max-retry escape
+  hatch, leaving a feature able to loop `qa → act` indefinitely. The
+  `recordQaResult` action then wrote those blanks back to pdca-status as nulls,
+  erasing measurements. Switches to `loadContext()` (falling back to
+  `createContext`) and extends `loadContext` to hydrate the QA slice, reading
+  quality-metrics first and pdca-status second. Adds
+  `guardrails.loopBreaker.maxQaRetries` to `bkit.config.json` so the retry
+  ceiling is a real, editable setting rather than an inline default.
+
+- **Chrome MCP detection read an environment variable Claude Code never sets.**
+  Both `lib/qa/chrome-bridge.js` and a duplicate copy in
+  `lib/pdca/state-transitions.js` tested `process.env.MCP_SERVERS`, which is
+  always empty under Claude Code, so `chromeAvailable` was false on 100% of runs
+  and L3/L4/L5 were skipped every time — described in qa-lead's own docs as
+  normal fallback, which is how a permanently dark half of the test matrix
+  passed for a feature. Detection is now layered, most authoritative first: a
+  runtime probe qa-lead records in `.bkit/runtime/qa-capabilities.json` (only the
+  agent holds the Chrome MCP tools, so only the agent can observe whether they
+  answer), a `BKIT_CHROME_MCP=1|0` operator override, `MCP_SERVERS` for
+  back-compat, then MCP config files. The duplicate detector now delegates to the
+  bridge instead of drifting alongside it.
+
+Regression coverage: `test/regression/qa-pipeline-wiring.test.js` (23 TC),
+registered in `test/run-all.js`.
+
 ## [2.1.37] - 2026-08-15
 
 > **One-Liner (EN)**: A Claude Code plugin that verifies AI-generated code against its own design specs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,66 @@ these can produce a failing run — they produce a run that looks fine.
 Regression coverage: `test/regression/qa-pipeline-wiring.test.js` (23 TC),
 registered in `test/run-all.js`.
 
+### Fixed — QA follow-ups
+
+The rest of the same audit, plus one root cause that only surfaced while fixing
+the first four.
+
+- **No Stop handler had ever seen its hook payload.** `unified-stop.js` reads the
+  payload with `readStdinBounded`, which destroys stdin on resolve (Issue #139),
+  and then dispatches the per-agent handler with `require()` — same process,
+  stdin already drained. All six metric-collecting handlers are self-executing
+  and call `readStdinSync()` for themselves, so the parent saw the payload and
+  the child saw `{}`. Measured with a two-file harness, not inferred. This is
+  the reason no handler ever had a `transcript_path` to read, and it means the
+  C-1 fix above was necessary but not sufficient on its own. `lib/core/io.js`
+  now remembers the payload the process read and hands it to later readers; one
+  hook process handles one event, so there is no staleness to reason about.
+
+- **Two more handlers regexed their own guidance string.** `analysis-stop.js` and
+  `qa-stop.js` both `require` `readStdinSync` and never call it, matching their
+  metric patterns against the `message` constant declared at the top of the same
+  file. Those patterns cannot match it, so M2 was written at its 75 baseline and
+  M5 at 0 — "no errors found" — on every run regardless of what code-analyzer or
+  qa-monitor reported.
+
+- **`QA_RETRY` was defined but never emitted.** `act → qa` is the only route back
+  into QA after a failure, and `unified-stop` mapped the act phase to
+  `ANALYZE_DONE` unconditionally, so a QA failure rejoined the ordinary
+  `act → check` loop and never returned to the phase that rejected it. The
+  transition, its retry counter, and its `initQaPhase` action were all
+  unreachable. `QA_FAIL` now records the debt via a new `markQaRetryPending`
+  action and unified-stop pays it on the next act completion. Separately,
+  `initQaPhase` read `ctx.qaRetryCount || 0` and wrote the same value back — the
+  counter never moved, so `guardQaMaxRetryReached` could not fire however many
+  times a feature went round. It now advances on `QA_RETRY` and only on it.
+
+- **qa-lead never dispatched qa-monitor.** It is declared in the agent's tools and
+  named in its description as one of four coordinated agents, but no step called
+  it, so the QA phase reported test outcomes with no runtime log evidence behind
+  them. Added as Phase 3.5.
+
+- **qa-test-planner could not write the test plan it exists to produce.** `Write`
+  was on its `disallowedTools` list while its stated role was producing "test
+  plan documents", so the plan survived only as conversational text — and
+  qa-lead ran the planner and the generator concurrently anyway, leaving the
+  generator to write tests against a plan that did not exist yet. The planner now
+  writes `docs/05-qa/{feature}.test-plan.md`, the generator reads that path and
+  stops if it is missing, and qa-lead sequences the two. `Bash` stays denied.
+
+- **The pre-release scanner scanned bkit, not the caller's project.**
+  `pre-release-check.sh` set `PROJECT_ROOT` from its own location and used it for
+  both loading scanner code and choosing what to scan, so a user running it got a
+  report about bkit's source. Split into `BKIT_ROOT` (code) and `SCAN_ROOT`
+  (target, defaulting to `$CLAUDE_PROJECT_DIR`), with `--root DIR` and a `--self`
+  opt-in for the old behaviour. `skills/qa-phase/SKILL.md` invoked it by relative
+  path, which resolves to nothing where the skill actually runs — now
+  `${PLUGIN_ROOT}`-absolute — and documented four scanners where five ship;
+  `wiring` was missing from both the table and the report template.
+
+Regression coverage: `test/regression/qa-followups.test.js` (27 TC), registered
+in `test/run-all.js`.
+
 ## [2.1.37] - 2026-08-15
 
 > **One-Liner (EN)**: A Claude Code plugin that verifies AI-generated code against its own design specs.

--- a/agents/qa-lead.md
+++ b/agents/qa-lead.md
@@ -58,10 +58,18 @@ Orchestrates QA phase of the PDCA cycle. Runs L1-L5 tests with Chrome MCP integr
 3. Check existing tests: test/, tests/, __tests__/ directories
 4. Read Check phase result: `docs/03-analysis/{feature}.analysis.md`
 
-### Phase 2: Parallel Analysis (3 agents concurrent)
-- Task(qa-test-planner): Design doc → Test Plan generation
-- Task(qa-test-generator): Test Plan + code → Test Code generation
-- Task(qa-debug-analyst): Debug config + error monitoring setup
+### Phase 2: Analysis
+
+The generator's input is the planner's output, so those two are **sequential**.
+Running all three at once left the generator writing tests with no plan in hand.
+
+1. **Task(qa-test-planner)** — design doc → test plan. It writes the plan to
+   `docs/05-qa/{feature}.test-plan.md`; wait for that file before step 2.
+2. **Task(qa-test-generator)** — that test plan + the code → test code.
+
+Independent of both, and safe to run alongside step 1:
+
+- **Task(qa-debug-analyst)** — debug config + error monitoring setup.
 
 ### Phase 2.5: Record Chrome MCP capability (qa-lead direct)
 
@@ -88,6 +96,17 @@ Chrome not installed:
 - L3-L5 auto-skipped
 - QA verdict based on L1+L2 results only
 - QA report notes "Chrome MCP unavailable — L3-L5 skipped"
+
+### Phase 3.5: Runtime log evidence (Task(qa-monitor))
+
+**Task(qa-monitor)** — collect runtime log evidence for the levels just run, and
+report the runtime error count that Phase 4 needs.
+
+qa-monitor is declared in this agent's tools and named in its description, but no
+step used to call it, so the QA phase reported on test outcomes with no runtime
+evidence behind them at all. Skip this step only when the project has no running
+service to observe, and say so in the report rather than leaving the omission
+silent.
 
 ### Phase 4: Result Analysis & Report
 1. Aggregate test results (passRate, failedTests, criticalCount)

--- a/agents/qa-lead.md
+++ b/agents/qa-lead.md
@@ -63,6 +63,20 @@ Orchestrates QA phase of the PDCA cycle. Runs L1-L5 tests with Chrome MCP integr
 - Task(qa-test-generator): Test Plan + code → Test Code generation
 - Task(qa-debug-analyst): Debug config + error monitoring setup
 
+### Phase 2.5: Record Chrome MCP capability (qa-lead direct)
+
+You hold the Chrome MCP tools; the hooks that later read QA state do not, and no
+environment variable tells them. So before L3, probe once and write the answer
+down — otherwise every downstream reader has to guess, and guessing false is
+what kept L3-L5 permanently skipped:
+
+1. Try one cheap Chrome MCP call (e.g. `tabs_create_mcp`).
+2. Record the outcome via Bash:
+   `node -e "require('${PLUGIN_ROOT}/lib/qa').recordChromeProbe(<true|false>)"`
+
+This writes `.bkit/runtime/qa-capabilities.json`, which `checkChromeAvailable()`
+treats as the authoritative signal.
+
 ### Phase 3: Test Execution (qa-lead direct)
 L1 (Unit): `node --test` or `npx jest` execution (Bash)
 L2 (API): curl/fetch-based API endpoint verification (Bash)

--- a/agents/qa-test-generator.md
+++ b/agents/qa-test-generator.md
@@ -32,6 +32,11 @@ Generates executable test code from test plans.
 ## Role
 Create executable test code based on Test Plans.
 
+## Input
+Read the plan qa-test-planner wrote to `docs/05-qa/{feature}.test-plan.md`. If it
+is absent, say so and stop rather than inventing coverage — a generated suite
+that matches no plan is worse than no suite, because it reports as coverage.
+
 ## Output Paths
 - L1: `tests/unit/{feature}/*.test.js` (or .test.ts)
 - L2: `tests/api/{feature}/*.test.js`

--- a/agents/qa-test-planner.md
+++ b/agents/qa-test-planner.md
@@ -10,11 +10,11 @@ effort: medium
 maxTurns: 20
 memory: project
 disallowedTools:
-  - Write
   - Edit
   - Bash
 tools:
   - Read
+  - Write
   - Glob
   - Grep
   - Task(Explore)
@@ -34,6 +34,17 @@ Analyzes design documents and implementation code to generate L1-L5 test plans.
 
 ## Role
 Analyze design docs and implementation code to produce L1-L5 test plan documents.
+
+## Output Path
+
+Write the plan to `docs/05-qa/{feature}.test-plan.md`, with the JSON structure
+below in a fenced block.
+
+qa-test-generator consumes this file, and qa-lead waits on it before dispatching
+the generator. Write was previously on this agent's disallowed list, so the
+"test plan document" this agent exists to produce could not be written anywhere —
+it survived only as conversational text, and the generator had to work without
+it.
 
 ## Output Format
 Test plan JSON structure:

--- a/bkit.config.json
+++ b/bkit.config.json
@@ -195,6 +195,7 @@
     "destructiveDetection": true,
     "loopBreaker": {
       "maxPdcaIterations": 5,
+      "maxQaRetries": 3,
       "maxSameFileEdits": 10,
       "maxAgentRecursion": 3,
       "cooldownMs": 60000

--- a/lib/core/io.js
+++ b/lib/core/io.js
@@ -852,7 +852,43 @@ function withDispatchRecord(payload) {
   } catch (_) {
     /* observability must never break a hook */
   }
+  if (!_isEmptyPayload(payload)) _processPayload = payload;
   return payload;
+}
+
+/**
+ * The payload this process read, cached for readers that come after it.
+ *
+ * A hook process handles exactly one event, so there is exactly one payload to
+ * remember and no staleness to reason about.
+ *
+ * Why it has to be remembered: unified-stop.js reads the payload with
+ * `readStdinBounded`, which destroys stdin on resolve (Issue #139 — the Stop
+ * hook must never block on a write-end Claude Code holds open), and then
+ * dispatches the per-agent handler with `require()`, in the SAME process. Every
+ * one of those handlers is self-executing and calls `readStdinSync()` for
+ * itself, by which point the bytes are long gone: the parent sees the payload,
+ * the child sees `{}`. Measured, not inferred — a two-file harness reproduces it
+ * in isolation.
+ *
+ * That is why no Stop handler has ever had a `transcript_path` to read, and so
+ * why their metric extraction has always fallen through to defaults. Caching the
+ * payload here fixes every self-executing handler at once, including ones not
+ * yet written, rather than converting six handlers to a `run(context)` shape and
+ * leaving the seventh to rediscover this.
+ */
+let _processPayload = null;
+
+/**
+ * Whether a parsed payload carries nothing a handler could act on.
+ * @param {*} value
+ * @returns {boolean}
+ * @private
+ */
+function _isEmptyPayload(value) {
+  if (value == null) return true;
+  if (typeof value !== 'object') return false;
+  return Object.keys(value).length === 0;
 }
 
 /** Guard so repeated reader calls in one process install the listeners once. */
@@ -932,7 +968,15 @@ function installCrashRecorder(event) {
  * @returns {*}
  */
 function readStdinSync() {
-  return withDispatchRecord(readStdinSyncInner());
+  const value = readStdinSyncInner();
+  /*
+   * Empty read + a payload already taken in this process = a handler dispatched
+   * by another handler that drained stdin first. Hand back what was read rather
+   * than the `{}` that made every downstream metric fall through to its default.
+   * The dispatch is deliberately not re-recorded: one event, one ledger entry.
+   */
+  if (_isEmptyPayload(value) && _processPayload) return _processPayload;
+  return withDispatchRecord(value);
 }
 
 /**

--- a/lib/core/io.js
+++ b/lib/core/io.js
@@ -318,6 +318,87 @@ async function readStdin() {
 }
 
 /**
+ * Extract the assistant text a Stop handler wants to scan for metrics.
+ *
+ * Why this exists: `readStdinSync` returns the *parsed* hook payload — an
+ * object, never a string. Three Stop handlers were treating its return value
+ * as text and calling `.match()` on it, which throws TypeError on the first
+ * pattern and is then swallowed by the handler's own try/catch. The metrics
+ * those handlers exist to collect were never written, and the failure was
+ * invisible because the handler still printed its success message.
+ *
+ * The payload itself never carries the assistant's answer — only
+ * `transcript_path` does. So the text is read from the transcript's trailing
+ * assistant messages. Only `text` blocks are kept: `thinking` is not the
+ * agent's reported result, and `tool_use` blocks are structured input that
+ * would produce false regex hits (a tool argument containing "pass rate: 100%"
+ * is not a measurement).
+ *
+ * Falls back to `JSON.stringify(input)` when no transcript is readable, which
+ * matches what gap-detector-stop.js has always done — a string, so callers can
+ * regex it without crashing, even if it rarely matches.
+ *
+ * @param {*} input - Parsed hook payload (or a string, passed through)
+ * @param {Object} [options]
+ * @param {number} [options.maxMessages=5] - Trailing assistant messages to keep
+ * @returns {string} Text safe to run regex against — never null/undefined
+ */
+function readHookText(input, options = {}) {
+  if (typeof input === 'string') return input;
+  if (!input || typeof input !== 'object') return '';
+
+  const maxMessages = options.maxMessages || 5;
+  const transcriptPath = input.transcript_path || input.transcriptPath;
+
+  if (transcriptPath) {
+    try {
+      const lines = fs.readFileSync(transcriptPath, 'utf8').split('\n');
+      const collected = [];
+
+      for (let i = lines.length - 1; i >= 0 && collected.length < maxMessages; i--) {
+        if (!lines[i]) continue;
+
+        let entry;
+        try {
+          entry = JSON.parse(lines[i]);
+        } catch (_) {
+          continue; // partial write / non-JSON line — skip, don't abort
+        }
+        if (!entry || entry.type !== 'assistant') continue;
+
+        const content = entry.message && entry.message.content;
+        if (typeof content === 'string') {
+          collected.push(content);
+          continue;
+        }
+        if (!Array.isArray(content)) continue;
+
+        const text = content
+          .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+          .map((block) => block.text)
+          .join('\n');
+        if (text) collected.push(text);
+      }
+
+      if (collected.length > 0) {
+        return collected.reverse().join('\n');
+      }
+    } catch (e) {
+      getDebug().debugLog('io', 'readHookText transcript read failed', {
+        transcriptPath,
+        error: e && e.message,
+      });
+    }
+  }
+
+  try {
+    return JSON.stringify(input);
+  } catch (_) {
+    return '';
+  }
+}
+
+/**
  * Hook 입력 파싱
  *
  * H4 fix (audit): absent fields now return null (not '') so callers can
@@ -889,6 +970,7 @@ module.exports = {
   readStdinSync,
   readStdinBounded,
   readStdin,
+  readHookText,
   parseHookInput,
   outputAllow,
   outputBlock,

--- a/lib/pdca/state-machine.js
+++ b/lib/pdca/state-machine.js
@@ -370,6 +370,7 @@ function _loadQaContext(feature, featureData, getConfig) {
     qaPassRate: pick(m.qaPassRate, featureData.qaPassRate),
     qaCriticalCount: pick(m.qaCriticalCount, featureData.qaCriticalCount),
     qaRetryCount: featureData.qaRetryCount || 0,
+    qaRetryPending: featureData.qaRetryPending === true,
     maxQaRetries: getConfig('guardrails.loopBreaker.maxQaRetries', 3),
     chromeAvailable: featureData.chromeAvailable != null
       ? featureData.chromeAvailable

--- a/lib/pdca/state-machine.js
+++ b/lib/pdca/state-machine.js
@@ -30,6 +30,12 @@ function getPhase() {
   return _phase;
 }
 
+let _metrics = null;
+function getMetrics() {
+  if (!_metrics) { _metrics = require('../quality/metrics-collector'); }
+  return _metrics;
+}
+
 // S3a ENH-344: STATES/EVENTS/TRANSITIONS/GUARDS/ACTIONS extracted to ./state-transitions
 const { STATES, EVENTS, TRANSITIONS, GUARDS, ACTIONS } = require('./state-transitions');
 
@@ -319,6 +325,55 @@ function loadContext(feature) {
     workflowId: featureData.workflowId || 'default-pdca',
     timestamps: featureData.timestamps || {},
     metadata: featureData.metadata || {},
+    ..._loadQaContext(feature, featureData, getConfig),
+  };
+}
+
+/**
+ * Hydrate the QA slice of a StateMachineContext.
+ *
+ * The qa guards (`guardQaPass`, `guardQaMaxRetryReached`) read ctx.qaPassRate /
+ * ctx.qaCriticalCount / ctx.qaRetryCount, and no context builder ever supplied
+ * them. Every qa guard therefore evaluated against `undefined`: QA_PASS could
+ * not fire, and the max-retry escape hatch could not fire either, leaving a
+ * feature able to loop qa -> act indefinitely. `recordQaResult` then wrote the
+ * same undefined values back to pdca-status as nulls, erasing whatever had been
+ * measured.
+ *
+ * quality-metrics.json is the authoritative source — that is where the qa Stop
+ * handler writes M11/M14/M16 — so it is read first and pdca-status is the
+ * fallback for runs recorded before the metric existed.
+ *
+ * @param {string} feature
+ * @param {Object} featureData - pdca-status entry for the feature
+ * @param {function} getConfig
+ * @returns {Object} QA context slice
+ * @private
+ */
+function _loadQaContext(feature, featureData, getConfig) {
+  let gateMetrics = null;
+  try {
+    gateMetrics = getMetrics().toGateFormat(feature);
+  } catch (_) {
+    // metrics file missing/unreadable — fall back to pdca-status alone
+  }
+  const m = gateMetrics || {};
+
+  const pick = (...vals) => {
+    for (const v of vals) {
+      if (v != null) return v;
+    }
+    return null;
+  };
+
+  return {
+    qaPassRate: pick(m.qaPassRate, featureData.qaPassRate),
+    qaCriticalCount: pick(m.qaCriticalCount, featureData.qaCriticalCount),
+    qaRetryCount: featureData.qaRetryCount || 0,
+    maxQaRetries: getConfig('guardrails.loopBreaker.maxQaRetries', 3),
+    chromeAvailable: featureData.chromeAvailable != null
+      ? featureData.chromeAvailable
+      : null,
   };
 }
 

--- a/lib/pdca/state-transitions.js
+++ b/lib/pdca/state-transitions.js
@@ -50,13 +50,19 @@ function getPhase() {
 // ── Chrome MCP Availability Helper ──────────────────────────────────
 
 /**
- * Check Chrome MCP availability
+ * Check Chrome MCP availability.
+ *
+ * This used to be a second, independent copy of the `MCP_SERVERS` check that
+ * lib/qa/chrome-bridge.js also carried — two detectors that had to be fixed in
+ * two places and could disagree. It now delegates to the bridge, which is the
+ * module that owns the question. Lazy-required so a bridge load failure cannot
+ * break the state machine at import time.
+ *
  * @returns {boolean}
  */
 function _checkChromeMcpAvailable() {
   try {
-    const mcpServers = process.env.MCP_SERVERS || '';
-    return mcpServers.includes('claude-in-chrome');
+    return require('../qa/chrome-bridge').checkChromeAvailable().available;
   } catch (_) {
     return false;
   }

--- a/lib/pdca/state-transitions.js
+++ b/lib/pdca/state-transitions.js
@@ -47,6 +47,25 @@ function getPhase() {
   return _phase;
 }
 
+// ── Event Name Helper ───────────────────────────────────────────────
+
+/**
+ * Resolve an event identifier to its name.
+ *
+ * `transition()` accepts either a string or a `{event, target, guard}` object
+ * and passes the caller's raw form through to actions, so an action that
+ * branches on the event has to normalise it the same way the machine does.
+ *
+ * @param {string|{event:string}} event
+ * @returns {string|null}
+ * @private
+ */
+function _eventName(event) {
+  if (typeof event === 'string') return event;
+  if (event && typeof event === 'object' && typeof event.event === 'string') return event.event;
+  return null;
+}
+
 // ── Chrome MCP Availability Helper ──────────────────────────────────
 
 /**
@@ -162,7 +181,7 @@ const TRANSITIONS = [
   {
     from: 'qa', event: 'QA_FAIL', to: 'act',
     guard: null,
-    actions: ['recordTimestamp', 'recordQaResult'],
+    actions: ['recordTimestamp', 'recordQaResult', 'markQaRetryPending'],
     description: 'QA tests failed, return to Act for fixes'
   },
   {
@@ -600,16 +619,41 @@ const ACTIONS = {
   // ── QA Phase Actions (v2.1.1) ──
 
   /**
+   * Flag that this feature owes a QA retry.
+   *
+   * `act -> qa` (QA_RETRY) is the only route back into QA after a failure, and
+   * nothing emitted the event: unified-stop maps the act phase to ANALYZE_DONE
+   * unconditionally, so a QA failure went to act and then rejoined the ordinary
+   * act -> check loop, never returning to the phase that rejected it. The
+   * transition, its retry counter, and its `initQaPhase` action were all
+   * unreachable. This marks the debt on the status entry so unified-stop can
+   * pay it on the next act completion.
+   */
+  markQaRetryPending(ctx, _event) {
+    const { updatePdcaStatus } = getStatus();
+    updatePdcaStatus(ctx.feature, ctx.currentState, { qaRetryPending: true });
+  },
+
+  /**
    * Initialize QA phase state
    * Sets up QA context: test plan reference, Chrome availability, retry count
+   *
+   * Runs on both entries into qa — `check -> qa` (first attempt) and
+   * `act -> qa` (QA_RETRY) — so the retry counter advances on the retry event
+   * only. It previously read `ctx.qaRetryCount || 0` and wrote the same value
+   * straight back, which meant the counter never moved and
+   * `guardQaMaxRetryReached` could not fire no matter how many times a feature
+   * went round.
    */
-  initQaPhase(ctx, _event) {
+  initQaPhase(ctx, event) {
     const { debugLog } = getCore();
     const { updatePdcaStatus } = getStatus();
 
+    const isRetry = _eventName(event) === 'QA_RETRY';
+
     ctx.qaPassRate = null;
     ctx.qaCriticalCount = null;
-    ctx.qaRetryCount = ctx.qaRetryCount || 0;
+    ctx.qaRetryCount = (ctx.qaRetryCount || 0) + (isRetry ? 1 : 0);
     ctx.qaStartTime = new Date().toISOString();
 
     // Chrome MCP availability check
@@ -619,6 +663,9 @@ const ACTIONS = {
       qaRetryCount: ctx.qaRetryCount,
       chromeAvailable: ctx.chromeAvailable,
       qaStartTime: ctx.qaStartTime,
+      // Consumed by unified-stop to choose QA_RETRY over ANALYZE_DONE; cleared
+      // here because the retry it was requesting has now happened.
+      qaRetryPending: false,
     });
 
     debugLog('PDCA-SM', 'QA phase initialized', {

--- a/lib/qa/chrome-bridge.js
+++ b/lib/qa/chrome-bridge.js
@@ -7,51 +7,174 @@
  * Used by qa-lead agent for L3-L5 test execution.
  */
 
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
 let _core = null;
 function getCore() {
   if (!_core) { _core = require('../core'); }
   return _core;
 }
 
+/** Chrome MCP tool names exposed to qa-lead for L3-L5. */
+const CHROME_MCP_TOOLS = [
+  'tabs_create_mcp', 'navigate', 'form_input', 'find',
+  'get_page_text', 'read_console_messages', 'read_network_requests',
+  'gif_creator',
+];
+
+/** Server-name fragment that identifies the Chrome MCP server. */
+const CHROME_SERVER_HINT = 'claude-in-chrome';
+
 /**
  * @typedef {Object} ChromeAvailability
  * @property {boolean} available - Chrome MCP is accessible
  * @property {string} reason - Availability reason
  * @property {string[]} tools - Available Chrome MCP tool names
+ * @property {string} source - Which detection strategy decided the answer
  */
 
+function _projectDir() {
+  return process.env.CLAUDE_PROJECT_DIR || process.cwd();
+}
+
+function _readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (_) {
+    return null;
+  }
+}
+
 /**
- * Check Chrome MCP availability
- * Detection strategy:
- * 1. MCP_SERVERS env var includes 'claude-in-chrome'
+ * Look for a Chrome MCP server registration in the files that declare MCP
+ * servers. Config presence means "configured", not "connected" — it is weaker
+ * evidence than the runtime probe, which is why it is checked last.
+ * @returns {boolean}
+ * @private
+ */
+function _configDeclaresChrome() {
+  const root = _projectDir();
+  const candidates = [
+    path.join(root, '.mcp.json'),
+    path.join(root, '.claude', 'settings.json'),
+    path.join(root, '.claude', 'settings.local.json'),
+    path.join(os.homedir(), '.claude.json'),
+    path.join(os.homedir(), '.claude', 'settings.json'),
+  ];
+
+  for (const file of candidates) {
+    const json = _readJson(file);
+    if (!json) continue;
+
+    const names = [
+      ...Object.keys(json.mcpServers || {}),
+      ...(Array.isArray(json.enabledMcpjsonServers) ? json.enabledMcpjsonServers : []),
+    ];
+    if (names.some((n) => String(n).includes(CHROME_SERVER_HINT))) return true;
+
+    // ~/.claude.json nests per-project overrides one level down.
+    const projects = json.projects && typeof json.projects === 'object' ? json.projects : {};
+    for (const entry of Object.values(projects)) {
+      const nested = Object.keys((entry && entry.mcpServers) || {});
+      if (nested.some((n) => String(n).includes(CHROME_SERVER_HINT))) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check Chrome MCP availability.
+ *
+ * Detection used to be a single line — `process.env.MCP_SERVERS` — and Claude
+ * Code does not set that variable. It was therefore false on every run, so
+ * L3/L4/L5 were skipped 100% of the time even with Chrome MCP connected, and
+ * qa-lead's own docs described that skip as normal fallback, which made a
+ * permanently-dark half of the test matrix look like a feature.
+ *
+ * Strategies, most authoritative first:
+ *   1. Runtime probe recorded by qa-lead in `.bkit/runtime/qa-capabilities.json`.
+ *      Only the agent holds the Chrome MCP tools, so only the agent can observe
+ *      whether they actually answer. A hook process cannot.
+ *   2. `BKIT_CHROME_MCP=1|0` — explicit operator override, both directions.
+ *   3. `MCP_SERVERS` env (kept for back-compat with any harness that sets it).
+ *   4. MCP config files declaring a `claude-in-chrome` server.
  *
  * @returns {ChromeAvailability}
  */
 function checkChromeAvailable() {
   const { debugLog } = getCore();
 
-  // Strategy 1: Environment variable
-  const mcpServers = process.env.MCP_SERVERS || '';
-  if (mcpServers.includes('claude-in-chrome')) {
-    debugLog('QA-Chrome', 'Chrome MCP detected via MCP_SERVERS');
-    return {
-      available: true,
-      reason: 'Chrome MCP detected via MCP_SERVERS environment',
-      tools: [
-        'tabs_create_mcp', 'navigate', 'form_input', 'find',
-        'get_page_text', 'read_console_messages', 'read_network_requests',
-        'gif_creator',
-      ],
-    };
+  const decide = (available, reason, source) => {
+    debugLog('QA-Chrome', available ? 'Chrome MCP available' : 'Chrome MCP not available',
+      { reason, source });
+    return { available, reason, source, tools: available ? CHROME_MCP_TOOLS : [] };
+  };
+
+  // Strategy 1: runtime probe written by qa-lead (ground truth)
+  const cap = _readJson(path.join(_projectDir(), '.bkit', 'runtime', 'qa-capabilities.json'));
+  if (cap && cap.chromeMcp && typeof cap.chromeMcp.available === 'boolean') {
+    return decide(
+      cap.chromeMcp.available,
+      `Runtime probe by qa-lead at ${cap.chromeMcp.checkedAt || 'unknown time'}`,
+      'runtime-probe'
+    );
   }
 
-  // Not found
-  debugLog('QA-Chrome', 'Chrome MCP not available');
-  return {
-    available: false,
-    reason: 'Chrome MCP (claude-in-chrome) not found in MCP_SERVERS',
-    tools: [],
-  };
+  // Strategy 2: explicit override
+  const override = (process.env.BKIT_CHROME_MCP || '').trim().toLowerCase();
+  if (override === '1' || override === 'true') {
+    return decide(true, 'BKIT_CHROME_MCP override set to on', 'env-override');
+  }
+  if (override === '0' || override === 'false') {
+    return decide(false, 'BKIT_CHROME_MCP override set to off', 'env-override');
+  }
+
+  // Strategy 3: MCP_SERVERS env (back-compat)
+  if ((process.env.MCP_SERVERS || '').includes(CHROME_SERVER_HINT)) {
+    return decide(true, 'Chrome MCP detected via MCP_SERVERS environment', 'env-mcp-servers');
+  }
+
+  // Strategy 4: MCP config files
+  if (_configDeclaresChrome()) {
+    return decide(true, 'Chrome MCP server declared in MCP configuration', 'mcp-config');
+  }
+
+  return decide(
+    false,
+    'Chrome MCP (claude-in-chrome) not found via runtime probe, override, environment, or MCP config',
+    'none'
+  );
+}
+
+/**
+ * Record the result of a live Chrome MCP probe.
+ *
+ * qa-lead calls this (or writes the same file) once it has actually tried a
+ * Chrome MCP tool, turning a guess into an observation for every later reader.
+ *
+ * @param {boolean} available - Whether Chrome MCP tools responded
+ * @param {Object} [details] - Optional extra context to persist
+ * @returns {boolean} Whether the capability file was written
+ */
+function recordChromeProbe(available, details = {}) {
+  const { debugLog } = getCore();
+  const file = path.join(_projectDir(), '.bkit', 'runtime', 'qa-capabilities.json');
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const current = _readJson(file) || {};
+    current.chromeMcp = {
+      available: !!available,
+      checkedAt: new Date().toISOString(),
+      ...details,
+    };
+    fs.writeFileSync(file, JSON.stringify(current, null, 2));
+    return true;
+  } catch (e) {
+    debugLog('QA-Chrome', 'Failed to record Chrome probe', { error: e && e.message });
+    return false;
+  }
 }
 
 /**
@@ -100,6 +223,8 @@ function createChromeBridge() {
 }
 
 module.exports = {
+  CHROME_MCP_TOOLS,
   checkChromeAvailable,
+  recordChromeProbe,
   createChromeBridge,
 };

--- a/lib/qa/index.js
+++ b/lib/qa/index.js
@@ -85,6 +85,7 @@ module.exports = {
 
   // Chrome Bridge
   checkChromeAvailable: chromeBridge.checkChromeAvailable,
+  recordChromeProbe: chromeBridge.recordChromeProbe,
   createChromeBridge: chromeBridge.createChromeBridge,
 
   // Report Generator

--- a/lib/quality/metrics-collector.js
+++ b/lib/quality/metrics-collector.js
@@ -1,5 +1,5 @@
 /**
- * Quality Metrics Collector - 10 Quality Metrics (M1-M10)
+ * Quality Metrics Collector - 16 Quality Metrics (M1-M16)
  * @module lib/quality/metrics-collector
  * @version 2.1.10
  *
@@ -16,12 +16,12 @@ const { STATE_PATHS } = require('../core/paths');
 const { MAX_QUALITY_HISTORY } = require('../core/constants');
 
 // ============================================================
-// Metric Specifications (M1-M10)
+// Metric Specifications (M1-M16)
 // ============================================================
 
 /**
  * @typedef {Object} MetricSpec
- * @property {string} id - Metric identifier (M1-M10)
+ * @property {string} id - Metric identifier (M1-M16)
  * @property {string} name - Human-readable metric name
  * @property {string} collector - Agent/source that collects this metric
  * @property {string} unit - Unit of measurement (%, count, 0-100, ms, hours, %p/iteration)
@@ -47,6 +47,18 @@ const METRIC_SPECS = {
   M13: { id: 'M13', name: 'E2E Scenario Coverage', collector: 'qa-lead', unit: '%', direction: 'higher' },
   M14: { id: 'M14', name: 'Runtime Error Count', collector: 'qa-debug-analyst', unit: 'count', direction: 'lower' },
   M15: { id: 'M15', name: 'Data Flow Integrity', collector: 'qa-lead', unit: '%', direction: 'higher' },
+
+  /*
+   * M16 — the gate's second QA pass condition had no metric behind it.
+   *
+   * gate-manager's `qa` gate has required `qaCriticalCount === 0` since v2.1.1,
+   * but no M-ID ever mapped to that name, so `toGateFormat` could not produce
+   * the key. `_evaluateCondition` treats an absent metric as not satisfied, so
+   * `passCount < totalPass` held on every run and the qa gate could never
+   * return 'pass' — QA was structurally unable to advance to Report regardless
+   * of how the tests actually went. The metric, not the gate, was missing.
+   */
+  M16: { id: 'M16', name: 'QA Critical Count', collector: 'qa-lead', unit: 'count', direction: 'lower' },
 };
 
 // ============================================================
@@ -54,7 +66,7 @@ const METRIC_SPECS = {
 // ============================================================
 
 /**
- * Mapping from metric ID (M1-M10) to gate-manager metric names.
+ * Mapping from metric ID (M1-M16) to gate-manager metric names.
  * gate-manager uses these keys in GATE_DEFINITIONS conditions.
  * @type {Record<string, string>}
  */
@@ -74,6 +86,7 @@ const METRIC_ID_TO_GATE_NAME = {
   M13: 'e2eScenarioCoverage',
   M14: 'runtimeErrorCount',
   M15: 'dataFlowIntegrity',
+  M16: 'qaCriticalCount',
 };
 
 /** @type {Record<string, string>} */
@@ -82,7 +95,7 @@ const GATE_NAME_TO_METRIC_ID = Object.fromEntries(
 );
 
 /**
- * Convert collected metrics (keyed by M1-M10) to gate-manager format
+ * Convert collected metrics (keyed by M1-M16) to gate-manager format
  * (keyed by friendly names like matchRate, codeQualityScore).
  *
  * @param {string} feature - Feature name
@@ -160,7 +173,7 @@ function _historyPath() {
  * Collect a single metric value.
  * Updates the current metrics snapshot for the feature.
  *
- * @param {string} metricId - Metric identifier (M1-M10)
+ * @param {string} metricId - Metric identifier (M1-M16)
  * @param {string} feature - Feature name
  * @param {number} value - Measured value
  * @param {string} [collector] - Override collector name (defaults to spec)

--- a/scripts/analysis-stop.js
+++ b/scripts/analysis-stop.js
@@ -21,7 +21,7 @@ Next steps:
 
 // v2.0.5: Comprehensive metrics collection (M1, M2, M3, M7)
 try {
-  const { readStdinSync } = require('../lib/core/io');
+  const { readStdinSync, readHookText } = require('../lib/core/io');
   const mc = require('../lib/quality/metrics-collector');
   const { extractFeatureFromContext, getPdcaStatusFull } = require('../lib/pdca/status');
   const currentStatus = getPdcaStatusFull();
@@ -34,9 +34,17 @@ try {
     mc.collectMetric('M1', f, matchRate, 'code-analyzer');
   }
 
-  // Read agent output for metric extraction
+  /*
+   * Read the ANALYZER's output, not our own.
+   *
+   * `message` is the guidance string declared at the top of this file. Matching
+   * the M2/M3/M7 patterns against it can only ever fail, so every metric below
+   * has always been written at its hardcoded default — M2 at the 75 baseline
+   * regardless of what code-analyzer actually reported. `readStdinSync` was
+   * already imported here and never called.
+   */
   let agentOutput = '';
-  try { agentOutput = typeof message === 'string' ? message : ''; } catch (_) {}
+  try { agentOutput = readHookText(readStdinSync()); } catch (_) { agentOutput = ''; }
 
   // M2: Code Quality Score — extract from code-analyzer output
   const qualityPattern = /(Quality|quality)\s*(Score|score|점수)[^0-9]*(\d+)/i;

--- a/scripts/qa-phase-stop.js
+++ b/scripts/qa-phase-stop.js
@@ -2,12 +2,12 @@
 /**
  * qa-phase-stop.js - QA Phase Stop Event Handler
  *
- * Collects M11-M15 metrics from QA execution results
+ * Collects M11-M16 metrics from QA execution results
  * and triggers appropriate state machine event (QA_PASS/QA_FAIL/QA_SKIP).
  */
 
 const path = require('path');
-const { readStdinSync, outputAllow } = require('../lib/core/io');
+const { readStdinSync, readHookText, outputAllow } = require('../lib/core/io');
 const { debugLog } = require('../lib/core/debug');
 // C7/C8/L2 (audit): atomic+locked reachability ping + single BKIT_VERSION source.
 // L2: this hook was the only Stop/Post handler without a reachability stamp.
@@ -24,9 +24,18 @@ try {
   const currentStatus = getPdcaStatusFull();
   const feature = extractFeatureFromContext({ currentStatus }) || 'unknown';
 
-  // Read QA phase output from stdin
+  /*
+   * Read the QA output as TEXT.
+   *
+   * `readStdinSync()` returns the parsed hook payload — an object. The previous
+   * code assigned it straight to `qaOutput` and called `.match()` on it, which
+   * throws TypeError on the very first pattern below. The outer catch swallowed
+   * it, so none of M11-M15 was ever collected while the handler still reported
+   * success. readHookText normalizes the payload to the assistant's actual
+   * reported text (via transcript_path) and always returns a string.
+   */
   let qaOutput = '';
-  try { qaOutput = readStdinSync() || ''; } catch (_) {}
+  try { qaOutput = readHookText(readStdinSync()); } catch (_) { qaOutput = ''; }
 
   // M11: QA Pass Rate
   const passRateMatch = qaOutput.match(/pass\s*rate[^0-9]*(\d+\.?\d*)\s*%/i);
@@ -53,8 +62,23 @@ try {
   const dataFlowIntegrity = integrityMatch ? parseFloat(integrityMatch[1]) : 100;
   mc.collectMetric('M15', feature, dataFlowIntegrity, 'qa-lead');
 
+  /*
+   * M16: QA Critical Count — the gate has required this since v2.1.1 but
+   * nothing ever produced it (see METRIC_SPECS.M16). qa-lead's Phase 4 reports
+   * it alongside passRate, so it is parsed from the same text.
+   *
+   * Absent means zero, matching M14's existing convention: "no criticals
+   * reported" is the normal shape of a clean run. This is safe because a run
+   * whose output cannot be parsed at all also yields qaPassRate 0, which fails
+   * the gate on its own — M16 defaulting to 0 cannot turn a broken run green.
+   */
+  const criticalMatch = qaOutput.match(/critical[^0-9]{0,20}(\d+)/i);
+  const qaCriticalCount = criticalMatch ? parseInt(criticalMatch[1], 10) : 0;
+  mc.collectMetric('M16', feature, qaCriticalCount, 'qa-lead');
+
   debugLog('QA-Phase-Stop', 'Metrics collected', {
-    feature, qaPassRate, testCoverage, e2eCoverage, runtimeErrors, dataFlowIntegrity
+    feature, qaPassRate, testCoverage, e2eCoverage, runtimeErrors, dataFlowIntegrity,
+    qaCriticalCount
   });
 } catch (e) {
   debugLog('QA-Phase-Stop', 'Metric collection failed', { error: e.message });

--- a/scripts/qa-stop.js
+++ b/scripts/qa-stop.js
@@ -20,16 +20,22 @@ Next steps:
 
 // v2.0.5: M5/M6 metrics collection with actual extraction
 try {
-  const { readStdinSync } = require('../lib/core/io');
+  const { readStdinSync, readHookText } = require('../lib/core/io');
   const mc = require('../lib/quality/metrics-collector');
   const { extractFeatureFromContext, getPdcaStatusFull } = require('../lib/pdca/status');
   const currentStatus = getPdcaStatusFull();
   const feature = extractFeatureFromContext({ currentStatus });
   const f = feature || 'unknown';
 
-  // Read QA agent output
+  /*
+   * Read qa-monitor's output, not our own. `message` is this file's guidance
+   * string; the M5/M6 patterns never matched it, so runtime error rate has
+   * always been recorded as 0 and p95 as its default — "no errors found" for
+   * every session, measured or not. `readStdinSync` was already imported here
+   * and never called.
+   */
   let qaOutput = '';
-  try { qaOutput = typeof message === 'string' ? message : ''; } catch (_) {}
+  try { qaOutput = readHookText(readStdinSync()); } catch (_) { qaOutput = ''; }
 
   // M5: Runtime Error Rate — extract from QA log analysis
   const errorRatePattern = /(Error|error)\s*(Rate|rate|비율)[^0-9]*(\d+\.?\d*)/i;

--- a/scripts/qa/pre-release-check.sh
+++ b/scripts/qa/pre-release-check.sh
@@ -11,7 +11,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Where bkit's own scanner code lives. Always relative to this script.
+BKIT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# What gets scanned. These are two different things, and conflating them was the
+# bug: SCAN_ROOT used to be BKIT_ROOT, so a user running this from their own
+# project got a report about bkit's source instead of their code — a clean report
+# that said nothing about the thing they were about to release.
+SCAN_ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
 
 FORMAT="console"
 SCANNER=""
@@ -20,12 +28,18 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --json) FORMAT="json"; shift ;;
     --scanner) SCANNER="$2"; shift 2 ;;
+    --root) SCAN_ROOT="$(cd "$2" && pwd)"; shift 2 ;;
+    --self) SCAN_ROOT="$BKIT_ROOT"; shift ;;
     --help|-h)
-      echo "Usage: $0 [--json] [--scanner NAME]"
+      echo "Usage: $0 [--json] [--scanner NAME] [--root DIR] [--self]"
+      echo ""
+      echo "Scans \$CLAUDE_PROJECT_DIR (or the current directory) by default."
       echo ""
       echo "Options:"
       echo "  --json           Output results as JSON"
       echo "  --scanner NAME   Run a specific scanner (dead-code, config-audit, completeness, shell-escape, wiring)"
+      echo "  --root DIR       Scan DIR instead of the default"
+      echo "  --self           Scan bkit's own source (what this script used to do unconditionally)"
       echo "  --help           Show this help"
       echo ""
       echo "Scanners:"
@@ -42,8 +56,8 @@ done
 
 if [ -n "$SCANNER" ]; then
   node -e "
-    const qa = require('${PROJECT_ROOT}/lib/qa');
-    qa.runScanner('${SCANNER}', { rootDir: '${PROJECT_ROOT}' })
+    const qa = require('${BKIT_ROOT}/lib/qa');
+    qa.runScanner('${SCANNER}', { rootDir: '${SCAN_ROOT}' })
       .then(r => {
         if ('${FORMAT}' === 'json') {
           console.log(JSON.stringify(r, null, 2));
@@ -56,13 +70,13 @@ if [ -n "$SCANNER" ]; then
   "
 else
   node -e "
-    const qa = require('${PROJECT_ROOT}/lib/qa');
-    qa.runAllScanners({ rootDir: '${PROJECT_ROOT}' })
+    const qa = require('${BKIT_ROOT}/lib/qa');
+    qa.runAllScanners({ rootDir: '${SCAN_ROOT}' })
       .then(r => {
         if ('${FORMAT}' === 'json') {
           console.log(JSON.stringify(r, null, 2));
         } else {
-          const reporter = require('${PROJECT_ROOT}/lib/qa/reporter');
+          const reporter = require('${BKIT_ROOT}/lib/qa/reporter');
           console.log(reporter.formatSummaryReport(r));
           for (const [name, result] of Object.entries(r.scanners)) {
             if (result.issues.length > 0) {

--- a/scripts/unified-stop.js
+++ b/scripts/unified-stop.js
@@ -440,7 +440,16 @@ if (feature && currentPhase) {
       } else if (phase === 'do') {
         event = 'DO_COMPLETE';
       } else if (phase === 'act') {
-        event = 'ANALYZE_DONE';
+        /*
+         * A feature that arrived in act because QA rejected it owes QA another
+         * look. Mapping act to ANALYZE_DONE unconditionally sent it back into
+         * the act -> check loop instead, so `act -> qa` (QA_RETRY) — and the
+         * retry counter and initQaPhase hanging off it — were unreachable.
+         */
+        const actStatus = getPdcaStatusFull();
+        event = actStatus?.features?.[feature]?.qaRetryPending
+          ? 'QA_RETRY'
+          : 'ANALYZE_DONE';
       } else if (phase === 'report') {
         event = 'REPORT_DONE';
       }

--- a/scripts/unified-stop.js
+++ b/scripts/unified-stop.js
@@ -392,7 +392,18 @@ if (feature && currentPhase) {
   try {
     const sm = getStateMachine();
     if (sm) {
-      const ctx = sm.createContext(feature);
+      /*
+       * loadContext, not createContext.
+       *
+       * createContext returns a blank context — matchRate 0, no qa fields at
+       * all — so every guard downstream evaluated against values this session
+       * had never measured. guardQaPass could not pass, guardQaMaxRetryReached
+       * could not release the qa -> act loop, and the recordQaResult action
+       * wrote the blanks back over real measurements. loadContext hydrates from
+       * pdca-status and quality-metrics; createContext stays as the fallback
+       * for a feature with no status entry yet.
+       */
+      const ctx = sm.loadContext(feature) || sm.createContext(feature);
 
       // Determine FSM event based on gate verdict + phase
       let event = null;

--- a/skills/qa-phase/SKILL.md
+++ b/skills/qa-phase/SKILL.md
@@ -57,7 +57,11 @@ Before running L1 tests, execute the automated quality scanners to catch structu
 
 ### Steps
 
-1. Run `scripts/qa/pre-release-check.sh` via Bash
+1. Run `bash ${PLUGIN_ROOT}/scripts/qa/pre-release-check.sh` via Bash.
+   The path must be absolute: the script ships inside the plugin, not in the
+   user's project, so a relative `scripts/qa/...` resolves to nothing wherever
+   this skill actually runs. The script scans `$CLAUDE_PROJECT_DIR` (falling back
+   to the working directory) — pass `--root DIR` to point it elsewhere.
 2. Parse the output for CRITICAL / WARNING / INFO counts
 3. **If CRITICAL issues found**:
    - Report all CRITICAL issues with file paths and suggested fixes
@@ -80,6 +84,7 @@ Before running L1 tests, execute the automated quality scanners to catch structu
 | config-audit | Unreferenced config keys, hardcoded values, missing paths | CRITICAL / WARNING / INFO |
 | completeness | Missing agents, long descriptions, missing effort | CRITICAL / WARNING / INFO |
 | shell-escape | Bare $N in awk, unescaped backticks, unsafe heredocs | CRITICAL / WARNING |
+| wiring | Exported but never called functions | WARNING |
 
 ### QA Report Integration
 
@@ -92,6 +97,7 @@ When scanner results are available, include them in the QA report:
 - **Scanner**: config-audit — 0 CRITICAL, 0 WARNING, 2 INFO
 - **Scanner**: completeness — 0 CRITICAL, 0 WARNING, 1 INFO
 - **Scanner**: shell-escape — 0 CRITICAL, 0 WARNING, 0 INFO
+- **Scanner**: wiring — 0 CRITICAL, 1 WARNING, 0 INFO
 
 **Overall**: PASS (0 CRITICAL issues)
 ```

--- a/test/regression/qa-followups.test.js
+++ b/test/regression/qa-followups.test.js
@@ -1,0 +1,227 @@
+'use strict';
+/**
+ * Regression tests for the QA follow-up defects.
+ * 21 TC | console.assert based | no external dependencies
+ *
+ * Companion to qa-pipeline-wiring.test.js. Same family of defect — a component
+ * that reports success while doing nothing — found in the same audit.
+ *
+ *   F-0  unified-stop drains stdin, then dispatches self-executing handlers
+ *        with require() in the SAME process, so every sub-handler read `{}`.
+ *        No Stop handler had ever seen transcript_path.
+ *   F-1  analysis-stop / qa-stop regexed their own hardcoded guidance string,
+ *        so M2 was always 75 and M5 always 0.
+ *   F-2  QA_RETRY (act -> qa) was never emitted, and initQaPhase never advanced
+ *        the retry counter, so the max-retry guard could not fire.
+ *   F-3  qa-lead never dispatched qa-monitor despite declaring it.
+ *   F-4  qa-test-planner could not write the test plan it exists to produce.
+ *   F-5  pre-release-check.sh scanned bkit rather than the user's project.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const REPO = path.resolve(__dirname, '../..');
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bkit-qa-followups-'));
+fs.mkdirSync(path.join(tmpDir, '.bkit', 'state'), { recursive: true });
+
+const platformPath = require.resolve('../../lib/core/platform');
+const origPlatform = require(platformPath);
+require.cache[platformPath] = {
+  id: platformPath,
+  filename: platformPath,
+  loaded: true,
+  exports: { ...origPlatform, PROJECT_DIR: tmpDir },
+};
+const origProjectDirEnv = process.env.CLAUDE_PROJECT_DIR;
+process.env.CLAUDE_PROJECT_DIR = tmpDir;
+
+const transitions = require('../../lib/pdca/state-transitions');
+const sm = require('../../lib/pdca/state-machine');
+
+let passed = 0, failed = 0, total = 0, skipped = 0;
+const failures = [];
+
+function assert(id, condition, message) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${id} - ${message}`); }
+  else { failed++; failures.push({ id, message }); console.error(`  FAIL: ${id} - ${message}`); }
+}
+
+function read(rel) {
+  return fs.readFileSync(path.join(REPO, rel), 'utf8');
+}
+
+console.log('\n=== qa-followups.test.js ===\n');
+
+// --- F-0: a second reader in the same process gets the payload ---
+
+// Reproduces the executeHandler dispatch exactly: parent drains stdin with the
+// bounded reader (which destroys the stream), then requires a child that calls
+// readStdinSync for itself.
+const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bkit-stdin-probe-'));
+fs.writeFileSync(path.join(probeDir, 'child.js'),
+  `const { readStdinSync } = require(${JSON.stringify(path.join(REPO, 'lib/core/io'))});\n` +
+  `console.log('CHILD:' + JSON.stringify(readStdinSync()));\n`);
+fs.writeFileSync(path.join(probeDir, 'parent.js'),
+  `const { readStdinBounded } = require(${JSON.stringify(path.join(REPO, 'lib/core/io'))});\n` +
+  `(async () => {\n` +
+  `  const ctx = await readStdinBounded(2000);\n` +
+  `  console.log('PARENT:' + JSON.stringify(ctx));\n` +
+  `  require('./child.js');\n` +
+  `})();\n`);
+
+let probeOut = '';
+try {
+  probeOut = execFileSync('node', [path.join(probeDir, 'parent.js')], {
+    input: '{"hook_event_name":"Stop","transcript_path":"/tmp/probe.jsonl"}',
+    encoding: 'utf8',
+    timeout: 15000,
+    env: { ...process.env, BKIT_HOOK_DISPATCH_RECORD: '0' },
+  });
+} catch (e) {
+  probeOut = String((e.stdout || '') + (e.stderr || ''));
+}
+
+const parentLine = (probeOut.match(/^PARENT:(.*)$/m) || [])[1] || '';
+const childLine = (probeOut.match(/^CHILD:(.*)$/m) || [])[1] || '';
+
+assert('QF-001', parentLine.includes('transcript_path'),
+  'Parent reader receives the payload');
+assert('QF-002', childLine.includes('transcript_path'),
+  'Child handler receives the payload too (was {} — the F-0 defect)');
+assert('QF-003', childLine !== '{}',
+  'Child no longer reads an empty object after stdin was destroyed');
+
+fs.rmSync(probeDir, { recursive: true, force: true });
+
+// --- F-1: the two handlers read the agent's output, not their own message ---
+
+const analysisSrc = read('scripts/analysis-stop.js');
+const qaStopSrc = read('scripts/qa-stop.js');
+
+assert('QF-004', !/agentOutput\s*=\s*typeof message/.test(analysisSrc),
+  'analysis-stop no longer regexes its own guidance string');
+assert('QF-005', /readHookText\(readStdinSync\(\)\)/.test(analysisSrc),
+  'analysis-stop reads the payload it already imported a reader for');
+assert('QF-006', !/qaOutput\s*=\s*typeof message/.test(qaStopSrc),
+  'qa-stop no longer regexes its own guidance string');
+assert('QF-007', /readHookText\(readStdinSync\(\)\)/.test(qaStopSrc),
+  'qa-stop reads the payload');
+assert('QF-008', /readStdinSync,\s*readHookText/.test(analysisSrc) &&
+  /readStdinSync,\s*readHookText/.test(qaStopSrc),
+  'Both import the text helper alongside the reader');
+
+// --- F-2: QA_RETRY is reachable, and the retry counter advances ---
+
+const qaFail = transitions.TRANSITIONS.find(t => t.from === 'qa' && t.event === 'QA_FAIL');
+assert('QF-009', qaFail && qaFail.actions.includes('markQaRetryPending'),
+  'QA_FAIL records that a retry is owed');
+assert('QF-010', typeof transitions.ACTIONS.markQaRetryPending === 'function',
+  'markQaRetryPending action exists');
+
+const stopSrc = read('scripts/unified-stop.js');
+assert('QF-011', /qaRetryPending[\s\S]{0,80}QA_RETRY/.test(stopSrc),
+  'unified-stop emits QA_RETRY when a retry is pending');
+assert('QF-012', /ANALYZE_DONE/.test(stopSrc),
+  'ANALYZE_DONE remains the path for an ordinary act completion');
+
+// initQaPhase advances the counter on retry, and only on retry.
+const FEATURE = 'qa-followup-feature';
+require('../../lib/pdca/status')
+  .updatePdcaStatus(FEATURE, 'qa', { qaRetryCount: 0 }, { requireDocs: false });
+
+const firstEntry = { feature: FEATURE, currentState: 'qa', qaRetryCount: 0 };
+transitions.ACTIONS.initQaPhase(firstEntry, 'MATCH_PASS');
+assert('QF-013', firstEntry.qaRetryCount === 0,
+  'First entry into qa does not count as a retry');
+
+const retryEntry = { feature: FEATURE, currentState: 'qa', qaRetryCount: 0 };
+transitions.ACTIONS.initQaPhase(retryEntry, 'QA_RETRY');
+assert('QF-014', retryEntry.qaRetryCount === 1,
+  'QA_RETRY advances the counter (it never moved before)');
+
+const thirdEntry = { feature: FEATURE, currentState: 'qa', qaRetryCount: 2 };
+transitions.ACTIONS.initQaPhase(thirdEntry, { event: 'QA_RETRY' });
+assert('QF-015', thirdEntry.qaRetryCount === 3,
+  'Counter advances for the object event form too');
+
+// With the counter moving, the escape hatch can now fire.
+assert('QF-016', transitions.GUARDS.guardQaMaxRetryReached({ qaRetryCount: 3, maxQaRetries: 3 }),
+  'Max-retry guard fires once the ceiling is reached');
+assert('QF-017', !transitions.GUARDS.guardQaMaxRetryReached({ qaRetryCount: 1, maxQaRetries: 3 }),
+  'Max-retry guard stays quiet below the ceiling');
+
+const hydrated = sm.loadContext(FEATURE);
+assert('QF-018', hydrated && typeof hydrated.qaRetryPending === 'boolean',
+  'loadContext carries qaRetryPending so the guard sees real state');
+
+// --- F-3 / F-4: qa-lead dispatches qa-monitor; planner can write its plan ---
+
+const leadDoc = read('agents/qa-lead.md');
+const plannerDoc = read('agents/qa-test-planner.md');
+const generatorDoc = read('agents/qa-test-generator.md');
+
+assert('QF-019', /Task\(qa-monitor\)/.test(leadDoc.split('## Orchestration Protocol')[1] || ''),
+  'qa-lead actually dispatches qa-monitor in its protocol, not just its tool list');
+
+const plannerFront = plannerDoc.split('---')[1] || '';
+
+// Read each list as its own block. A regex spanning from `disallowedTools:` to
+// the first `- Write` walks straight into the `tools:` list below it and reports
+// the allow entry as a denial.
+function yamlList(front, key) {
+  const lines = front.split('\n');
+  const start = lines.findIndex(l => l.trim() === `${key}:`);
+  if (start === -1) return [];
+  const out = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^\s+-\s+(.+?)\s*$/);
+    if (!m) break;
+    out.push(m[1]);
+  }
+  return out;
+}
+
+const plannerDenied = yamlList(plannerFront, 'disallowedTools');
+const plannerAllowed = yamlList(plannerFront, 'tools');
+assert('QF-020', !plannerDenied.includes('Write') && plannerAllowed.includes('Write'),
+  'qa-test-planner may write the test plan document it is defined to produce');
+assert('QF-020b', plannerDenied.includes('Bash'),
+  'qa-test-planner stays barred from Bash — planning is not execution');
+assert('QF-021', /docs\/05-qa\/\{feature\}\.test-plan\.md/.test(plannerDoc) &&
+  /docs\/05-qa\/\{feature\}\.test-plan\.md/.test(generatorDoc),
+  'Planner output path and generator input path are the same file');
+
+// --- F-5: the scanner targets the caller's project, not bkit ---
+
+const scriptSrc = read('scripts/qa/pre-release-check.sh');
+assert('QF-022', /SCAN_ROOT="\$\{CLAUDE_PROJECT_DIR:-\$PWD\}"/.test(scriptSrc),
+  'Scan root defaults to the calling project');
+assert('QF-023', /require\('\$\{BKIT_ROOT\}\/lib\/qa'\)/.test(scriptSrc),
+  'Scanner code is still resolved relative to the script itself');
+assert('QF-024', /--self/.test(scriptSrc),
+  'Scanning bkit itself remains available, but is now opt-in');
+
+const skillSrc = read('skills/qa-phase/SKILL.md');
+assert('QF-025', /\$\{PLUGIN_ROOT\}\/scripts\/qa\/pre-release-check\.sh/.test(skillSrc),
+  'Skill invokes the script by absolute plugin path');
+assert('QF-026', /\|\s*wiring\s*\|/.test(skillSrc),
+  'Skill documents all five scanners, including wiring');
+
+// --- Cleanup ---
+delete require.cache[platformPath];
+if (origProjectDirEnv === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+else process.env.CLAUDE_PROJECT_DIR = origProjectDirEnv;
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+// --- Summary ---
+console.log(`\nResults: ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`);
+if (failures.length > 0) {
+  console.log('Failures:');
+  failures.forEach(f => console.log(`  - ${f.id}: ${f.message}`));
+}
+
+module.exports = { passed, failed, total, skipped, failures };

--- a/test/regression/qa-pipeline-wiring.test.js
+++ b/test/regression/qa-pipeline-wiring.test.js
@@ -1,0 +1,194 @@
+'use strict';
+/**
+ * Regression tests for the QA pipeline wiring defects.
+ * 18 TC | console.assert based | no external dependencies
+ *
+ * Each defect below was silent: the QA phase reported success while the value
+ * it exists to produce never reached the gate. These tests pin the four repairs
+ * so a future refactor cannot quietly restore the dark path.
+ *
+ *   C-1  readStdinSync returns an object; qa-phase-stop called .match() on it,
+ *        threw TypeError, and swallowed it — M11-M15 never collected.
+ *   C-2  the qa gate required qaCriticalCount, which no metric ID produced, so
+ *        the gate could never return 'pass'.
+ *   C-3  unified-stop built a blank context, so every qa guard evaluated
+ *        against undefined and recordQaResult wrote nulls over measurements.
+ *   H-1  Chrome detection read MCP_SERVERS, which Claude Code never sets, so
+ *        L3-L5 were skipped on 100% of runs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bkit-qa-wiring-'));
+fs.mkdirSync(path.join(tmpDir, '.bkit', 'state'), { recursive: true });
+
+// Point every path-aware module at the sandbox.
+const platformPath = require.resolve('../../lib/core/platform');
+const origPlatform = require(platformPath);
+require.cache[platformPath] = {
+  id: platformPath,
+  filename: platformPath,
+  loaded: true,
+  exports: { ...origPlatform, PROJECT_DIR: tmpDir },
+};
+const origProjectDirEnv = process.env.CLAUDE_PROJECT_DIR;
+const origChromeEnv = process.env.BKIT_CHROME_MCP;
+const origMcpServersEnv = process.env.MCP_SERVERS;
+process.env.CLAUDE_PROJECT_DIR = tmpDir;
+delete process.env.BKIT_CHROME_MCP;
+delete process.env.MCP_SERVERS;
+
+const io = require('../../lib/core/io');
+const mc = require('../../lib/quality/metrics-collector');
+const gates = require('../../lib/quality/gate-manager');
+const sm = require('../../lib/pdca/state-machine');
+const chrome = require('../../lib/qa/chrome-bridge');
+
+let passed = 0, failed = 0, total = 0, skipped = 0;
+const failures = [];
+
+function assert(id, condition, message) {
+  total++;
+  if (condition) { passed++; console.log(`  PASS: ${id} - ${message}`); }
+  else { failed++; failures.push({ id, message }); console.error(`  FAIL: ${id} - ${message}`); }
+}
+
+console.log('\n=== qa-pipeline-wiring.test.js ===\n');
+
+// --- C-1: readHookText always yields regex-safe text ---
+
+assert('QW-001', typeof io.readHookText === 'function', 'readHookText is exported');
+assert('QW-002', typeof io.readHookText({ session_id: 'x' }) === 'string',
+  'Object payload returns a string, not the object');
+assert('QW-003', typeof io.readHookText(null) === 'string', 'null payload returns a string');
+assert('QW-004', typeof io.readHookText(undefined) === 'string', 'undefined payload returns a string');
+assert('QW-005', io.readHookText('already text') === 'already text', 'String payload passes through');
+
+// The original crash, reproduced: .match() on whatever the helper returns must
+// not throw for any payload shape a hook can receive.
+let matchThrew = false;
+try {
+  io.readHookText({ hook_event_name: 'Stop' }).match(/pass\s*rate[^0-9]*(\d+)/i);
+} catch (_) {
+  matchThrew = true;
+}
+assert('QW-006', !matchThrew, '.match() on the result never throws (the C-1 crash)');
+
+// Transcript extraction: assistant text only — thinking and tool_use blocks are
+// not reported results and would produce false metric hits.
+const transcriptPath = path.join(tmpDir, 'transcript.jsonl');
+fs.writeFileSync(transcriptPath, [
+  JSON.stringify({ type: 'user', message: { content: 'run qa' } }),
+  JSON.stringify({
+    type: 'assistant',
+    message: { content: [
+      { type: 'thinking', thinking: 'Pass Rate: 11%' },
+      { type: 'tool_use', name: 'Bash', input: { command: 'echo "Pass Rate: 22%"' } },
+      { type: 'text', text: 'QA complete. Pass Rate: 97.5% — Critical: 0' },
+    ] },
+  }),
+  '',
+].join('\n'));
+
+const text = io.readHookText({ transcript_path: transcriptPath });
+assert('QW-007', text.includes('Pass Rate: 97.5%'), 'Assistant text block is extracted');
+assert('QW-008', !text.includes('11%'), 'thinking block is excluded');
+assert('QW-009', !text.includes('22%'), 'tool_use block is excluded');
+assert('QW-010', io.readHookText({ transcript_path: '/nonexistent/x.jsonl' }).length > 0,
+  'Unreadable transcript falls back to a string instead of throwing');
+
+// --- C-2: qaCriticalCount has a metric behind it, so the qa gate can pass ---
+
+assert('QW-011', mc.METRIC_SPECS.M16 !== undefined, 'M16 metric spec exists');
+assert('QW-012', mc.METRIC_ID_TO_GATE_NAME.M16 === 'qaCriticalCount',
+  'M16 maps to the gate metric name qaCriticalCount');
+assert('QW-013', mc.GATE_NAME_TO_METRIC_ID.qaCriticalCount === 'M16',
+  'Inverse mapping resolves qaCriticalCount');
+
+const FEATURE = 'qa-wiring-feature';
+mc.collectMetric('M11', FEATURE, 100, 'qa-lead');          // qaPassRate
+mc.collectMetric('M14', FEATURE, 0, 'qa-debug-analyst');   // runtimeErrorCount
+mc.collectMetric('M16', FEATURE, 0, 'qa-lead');            // qaCriticalCount
+
+const gateMetrics = mc.toGateFormat(FEATURE);
+assert('QW-014', gateMetrics && gateMetrics.qaCriticalCount === 0,
+  'toGateFormat emits qaCriticalCount');
+
+const clean = gates.checkGate('qa', {
+  feature: FEATURE,
+  projectLevel: 'Dynamic',
+  metrics: gateMetrics,
+});
+assert('QW-015', clean.verdict === 'pass',
+  'A clean QA run now reaches verdict pass (was structurally impossible)');
+
+// Every pass condition must still be enforced — the fix supplies the metric,
+// it does not weaken the gate.
+const dirty = gates.checkGate('qa', {
+  feature: FEATURE,
+  projectLevel: 'Dynamic',
+  metrics: { ...gateMetrics, qaCriticalCount: 2 },
+});
+assert('QW-016', dirty.verdict === 'fail', 'A critical failure still blocks the qa gate');
+
+// --- C-3: loadContext hydrates the QA slice the guards read ---
+
+// unified-stop only reaches the state machine for a feature that already has a
+// pdca-status entry (that is where it reads the feature name from), so the
+// fixture mirrors that: status entry present, measurements in quality-metrics.
+// requireDocs:false — the L3 doc gate is not what is under test here.
+require('../../lib/pdca/status')
+  .updatePdcaStatus(FEATURE, 'qa', { qaRetryCount: 1 }, { requireDocs: false });
+
+const ctx = sm.loadContext(FEATURE) || sm.createContext(FEATURE);
+assert('QW-017', ctx.qaPassRate === 100 && ctx.qaCriticalCount === 0,
+  'loadContext hydrates qaPassRate/qaCriticalCount from collected metrics');
+assert('QW-018', typeof ctx.maxQaRetries === 'number' && ctx.maxQaRetries > 0,
+  'loadContext supplies maxQaRetries so the retry escape hatch can fire');
+
+// --- H-1: Chrome detection no longer depends on an env var CC never sets ---
+
+const noSignal = chrome.checkChromeAvailable();
+assert('QW-019', noSignal.available === false && noSignal.source === 'none',
+  'No signal present reports unavailable with an explicit source');
+
+process.env.BKIT_CHROME_MCP = '1';
+assert('QW-020', chrome.checkChromeAvailable().available === true,
+  'BKIT_CHROME_MCP=1 override turns detection on');
+process.env.BKIT_CHROME_MCP = '0';
+assert('QW-021', chrome.checkChromeAvailable().available === false,
+  'BKIT_CHROME_MCP=0 override turns detection off');
+delete process.env.BKIT_CHROME_MCP;
+
+chrome.recordChromeProbe(true, { probedWith: 'tabs_create_mcp' });
+const probed = chrome.checkChromeAvailable();
+assert('QW-022', probed.available === true && probed.source === 'runtime-probe',
+  'A recorded runtime probe is the authoritative signal');
+
+// The probe outranks a stale negative environment, which is the whole point:
+// only the agent can observe whether Chrome MCP actually answers.
+process.env.MCP_SERVERS = '';
+assert('QW-023', chrome.checkChromeAvailable().available === true,
+  'Runtime probe wins over an empty MCP_SERVERS environment');
+delete process.env.MCP_SERVERS;
+
+// --- Cleanup ---
+delete require.cache[platformPath];
+if (origProjectDirEnv === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+else process.env.CLAUDE_PROJECT_DIR = origProjectDirEnv;
+if (origChromeEnv === undefined) delete process.env.BKIT_CHROME_MCP;
+else process.env.BKIT_CHROME_MCP = origChromeEnv;
+if (origMcpServersEnv === undefined) delete process.env.MCP_SERVERS;
+else process.env.MCP_SERVERS = origMcpServersEnv;
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+// --- Summary ---
+console.log(`\nResults: ${passed}/${total} passed, ${failed} failed, ${skipped} skipped`);
+if (failures.length > 0) {
+  console.log('Failures:');
+  failures.forEach(f => console.log(`  - ${f.id}: ${f.message}`));
+}
+
+module.exports = { passed, failed, total, skipped, failures };

--- a/test/run-all.js
+++ b/test/run-all.js
@@ -326,8 +326,10 @@ const CATEGORIES = {
       'regression/gap-detector-unmeasured.test.js',
       // v2.1.37: permission-mode awareness + the five defects coupled to it.
       'regression/enh-466-473-permission-mode.test.js',
+      // QA pipeline wiring — four silent breaks between qa-lead and the qa gate.
+      'regression/qa-pipeline-wiring.test.js',
     ],
-    expected: 610,
+    expected: 633,
   },
   performance: {
     name: 'Performance Tests',

--- a/test/run-all.js
+++ b/test/run-all.js
@@ -328,8 +328,10 @@ const CATEGORIES = {
       'regression/enh-466-473-permission-mode.test.js',
       // QA pipeline wiring — four silent breaks between qa-lead and the qa gate.
       'regression/qa-pipeline-wiring.test.js',
+      // QA follow-ups — the stdin handoff, QA_RETRY, and three agent/skill gaps.
+      'regression/qa-followups.test.js',
     ],
-    expected: 633,
+    expected: 660,
   },
   performance: {
     name: 'Performance Tests',

--- a/test/unit/metrics-collector-full.test.js
+++ b/test/unit/metrics-collector-full.test.js
@@ -24,12 +24,13 @@ test('MC-01', 'METRIC_SPECS contains M1-M10 metric definitions', () => {
   }
 });
 
-// TC-02: METRIC_ID_TO_GATE_NAME maps M1-M10 to gate names
-test('MC-02', 'METRIC_ID_TO_GATE_NAME maps all 10 metric IDs', () => {
+// TC-02: METRIC_ID_TO_GATE_NAME maps M1-M16 to gate names
+test('MC-02', 'METRIC_ID_TO_GATE_NAME maps all 16 metric IDs', () => {
   assert.ok(mc.METRIC_ID_TO_GATE_NAME && typeof mc.METRIC_ID_TO_GATE_NAME === 'object');
-  assert.strictEqual(Object.keys(mc.METRIC_ID_TO_GATE_NAME).length, 15, 'Must have 15 entries (M1-M15)');
+  assert.strictEqual(Object.keys(mc.METRIC_ID_TO_GATE_NAME).length, 16, 'Must have 16 entries (M1-M16)');
   assert.strictEqual(mc.METRIC_ID_TO_GATE_NAME.M1, 'matchRate');
   assert.strictEqual(mc.METRIC_ID_TO_GATE_NAME.M10, 'pdcaCycleTimeHours');
+  assert.strictEqual(mc.METRIC_ID_TO_GATE_NAME.M16, 'qaCriticalCount');
 });
 
 // TC-03: GATE_NAME_TO_METRIC_ID is the inverse mapping


### PR DESCRIPTION
> **Stacked on #151.** This branch is built on `fix/qa-pipeline-wiring`, so the diff shown here includes that commit until #151 merges. Review or merge #151 first; this PR's own change is commit `441d9f5`.

## What this is

The remaining findings from the same QA audit — the five listed as follow-ups at the bottom of #151 — plus **one root cause that only surfaced while fixing the first four**, and which makes #151's C-1 fix incomplete on its own.

Same family of defect throughout: a component that reports success while doing nothing.

## F-0 — no Stop handler has ever seen its hook payload

This one is new, and it is the reason the others look the way they do.

`scripts/unified-stop.js` reads the payload with `readStdinBounded`, which **destroys stdin on resolve** (`lib/core/io.js:242`, deliberate — Issue #139, the Stop hook must never block on a write-end Claude Code holds open). It then dispatches the per-agent handler with `require()` — same process. Every one of the six metric-collecting handlers is self-executing and calls `readStdinSync()` for itself, by which point the bytes are gone.

Measured, not inferred. A two-file harness reproducing `executeHandler`'s dispatch exactly:

```
$ echo '{"hook_event_name":"Stop","transcript_path":"/tmp/t.jsonl"}' | node parent.js
PARENT saw: {"hook_event_name":"Stop","transcript_path":"/tmp/t.jsonl"}
CHILD saw:  {}
```

So `qa-phase-stop`, `qa-stop`, `analysis-stop`, `gap-detector-stop`, `iterator-stop` and `pdca-skill-stop` have never had a `transcript_path` to read. #151 stopped the C-1 crash and gave the handler a way to resolve text — but with `{}` arriving, that resolution had nothing to work from. Both halves are needed.

**Fix:** `lib/core/io.js` remembers the payload the process read and returns it to a later reader whose own read comes up empty. A hook process handles exactly one event, so there is one payload and no staleness to reason about. This repairs all six handlers at once — including ones not yet written — rather than converting six files to a `run(context)` shape and leaving the seventh to rediscover it.

## The five follow-ups

### F-1 — two handlers regex their own guidance string

`analysis-stop.js:38` and `qa-stop.js:30` both `require` `readStdinSync` and never call it:

```js
try { agentOutput = typeof message === 'string' ? message : ''; } catch (_) {}
```

`message` is the "Next steps: 1. Save report to…" constant declared at the top of the same file. The M2/M3/M7 and M5/M6 patterns cannot match it, so **M2 has always been written at its 75 baseline and M5 always at 0** — "no errors found", for every session, measured or not.

### F-2 — `QA_RETRY` is defined but never emitted

`act → qa` is the only route back into QA after a failure. `unified-stop` mapped the act phase to `ANALYZE_DONE` unconditionally, so a QA failure went to act and rejoined the ordinary `act → check` loop, never returning to the phase that rejected it. The transition, its retry counter, and its `initQaPhase` action were all unreachable.

There is a second half: `initQaPhase` read `ctx.qaRetryCount || 0` and wrote the same value straight back. The counter never moved, so `guardQaMaxRetryReached` could not fire however many times a feature went round — the escape hatch from the `qa ↔ act` loop that #151's C-3 restored.

**Fix:** `QA_FAIL` records the debt through a new `markQaRetryPending` action; unified-stop pays it on the next act completion; `initQaPhase` advances the counter on `QA_RETRY` and only on it (it also runs on first entry via `check → qa`, which is not a retry).

### F-3 — qa-lead never dispatches qa-monitor

Declared in the agent's tools, named in its description as one of four coordinated agents, called by no step. The QA phase reported test outcomes with no runtime log evidence behind them. Added as Phase 3.5, with an explicit instruction to say so in the report when there is no running service to observe rather than skipping silently.

### F-4 — qa-test-planner cannot write the test plan it exists to produce

`Write` was on its `disallowedTools` while its stated role is producing "test plan documents", and `skills/qa-phase` imports a `qa-test-plan.template.md` that nothing could fill. The plan survived only as conversational text — and qa-lead's Phase 2 ran the planner and the generator **concurrently** regardless, so the generator was writing tests against a plan that did not exist yet.

**Fix:** planner writes `docs/05-qa/{feature}.test-plan.md`; generator reads that path and stops if it is absent (a generated suite matching no plan is worse than none, because it reports as coverage); qa-lead sequences the two and keeps qa-debug-analyst parallel, since that one is genuinely independent. `Bash` stays denied — planning is not execution.

### F-5 — the pre-release scanner scans bkit, not the caller's project

`pre-release-check.sh` set `PROJECT_ROOT` from its own location and used it for **both** loading scanner code and choosing what to scan. A user running it got a clean report about bkit's source and nothing about the code they were about to release.

**Fix:** split into `BKIT_ROOT` (where the scanners live, always relative to the script) and `SCAN_ROOT` (what to scan, defaulting to `$CLAUDE_PROJECT_DIR`), plus `--root DIR` and a `--self` opt-in for the old behaviour. Verified the split actually bites:

```
config-audit    --self = 66 issues     caller's dir = 1 issue
```

Also in this file's blast radius: `skills/qa-phase/SKILL.md` invoked the script by **relative** path — it ships inside the plugin, so that resolves to nothing where the skill runs — and documented four scanners where five ship; `wiring` was missing from both the table and the report template.

## Verification

- New: `test/regression/qa-followups.test.js` — **27 TC, all passing**, registered in `test/run-all.js`. The F-0 case spawns the real parent/child dispatch and asserts on what the child actually received, rather than asserting on source text.
- `--regression` 846/846 · `--unit` 1953/1954 (1 skip) · `--integration` 609/609 · `--security` 267/267 · `--philosophy` 140/140 · `--architecture` 100/100 · `--behavioral` 45/45.
- `--contract` 759/761 — the one failure (`SSK-LIVE` / `primaryFeature`) is pre-existing, reproduced on a clean checkout of `main`.
- eslint on touched files improved: 21 → 19 errors, 46 → 44 warnings.
- `plugin.json` version untouched; CHANGELOG entry sits under the existing `[Unreleased]` heading.

Because F-0 changes a shared reader used by all 28 hook scripts, the full matrix above was run rather than the affected subset.

## Note

`gap-detector-stop.js`, `iterator-stop.js` and `pdca-skill-stop.js` also benefit from F-0 — they were reading `{}` too — but their extraction logic is otherwise untouched here. `gap-detector-stop.js` in particular does `JSON.stringify(input)` and regexes the payload envelope, which now at least contains a real payload; whether its patterns are the right ones is a separate question I did not want to answer inside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
